### PR TITLE
Fix off-by-one errors in CtoPstr and PtoCstr functions

### DIFF
--- a/src/RealmzCocoa.h
+++ b/src/RealmzCocoa.h
@@ -136,11 +136,10 @@ static inline void rintel2moto(Rect* r) {
 static inline void PtoCstr(Str255 x) {
   unsigned char len = x[0];
 
-  while (len--) {
-    x[0] = x[1];
-    x++;
+  for (int i = 0; i < len; i++) {
+    x[i] = x[i + 1];
   }
-  x[0] = '\0';
+  x[len] = '\0';
 }
 
 static inline void P2CStr(Str255 x) {


### PR DESCRIPTION
Address Sanitizer was reporting a stack-buffer-underflow here:

```
=================================================================
==19429==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7ffee2c0c5ff at pc 0x00010d005e3a bp 0x7ffee2c0c570 sp 0x7ffee2c0c568
READ of size 1 at 0x7ffee2c0c5ff thread T0
    #0 0x10d005e39 in CtoPstr RealmzCocoa.h:157
    #1 0x10d0066cc in MyrCDiStr MyrRealmz.c:277
    #2 0x10d1422d9 in ToolBoxInit main.c:1254
    #3 0x10d146e63 in main main.c:1561
    #4 0x7fff208a7f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)

Address 0x7ffee2c0c5ff is located in stack of thread T0 at offset 31 in frame
    #0 0x10d0065af in MyrCDiStr MyrRealmz.c:273

  This frame has 1 object(s):
    [32, 288) 'str' (line 274) <== Memory access at offset 31 underflows this variable
```

It turns out that there was an off-by-one error present in the `CtoPstr` function. This function takes a cstr, gets its length, then iterates backwards through the characters, starting with the last character before the `'\0'`, shifting each to the right one place, and putting the length of the string in the first byte. This appears to be a correct conversion function.

However, the while loop that was shifting each character to the right was iterating until the index variable `i` reached 0, but then indexing the string's `i -1`th element, effectively asking for `str[-1]`. This is what produced the stack buffer underflow. A proper `--i > 0` condition ensures that we do not reach for negative indices.

It looks like a similar off-by-one error is present in its companion function, `PtoCstr`, so I've correct that as well by replacing it with a more conventional `for` loop.