### PR TITLE
Parse DITL resources of type staticText

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(Realmz
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT "dwarf")
 # TODO(martin): We should eventually get everything to built without warnings and enable these flags.
 # if (MSVC)
 #     add_compile_options(/W4 /WX)

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -46,12 +46,20 @@ typedef struct {
   Picture p;
 } DialogItemPict;
 
+typedef struct {
+  Rect dispRect;
+  bool enabled;
+  Str255 text;
+} DialogItemStaticText;
+
 typedef union {
   DialogItemPict pict;
+  DialogItemStaticText staticText;
 } DialogItemType;
 
 typedef struct {
   enum DIALOG_ITEM_TYPE {
+    DIALOG_ITEM_TYPE_STATIC_TEXT,
     DIALOG_ITEM_TYPE_PICT,
   } type;
   DialogItemType dialogItem;


### PR DESCRIPTION
I was getting a NULL pointer dereference error from AddressSanitizer, indicating that the problem was in the `WindowManager_DrawDialog` function.

It turns out that, because we use an `enum` to represent the type of `DITL` stored in memory, and because the 0th value in that enum is the Quickdraw Picture Resource type of DITL, any `DialogItem` is initialized to one of type `DIALOG_ITEM_TYPE_PICT`. This is problematic because we don't have cases to handle the loading of each of the `DITL` types. In this case, the `background` dialog contains items of type `staticText`, which has a type code of 8. These failed to be loaded correctly, leaving them as `DIALOG_ITEM_TYPE_PICT`s in memory, but with no valid PICT resource ID, leaving the pict data pointer as NULL. When we attempted to draw the dialog and render these phantom Picture DITLs, we attempt to dereference that NULL pict data pointer.

This PR corrects the issue by detecting DITLs of type 8, and properly loads their representation according to _Macintosh Toolbox Essentials, 6-151_.

I've also set the `CMAKE_XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT` to `'dwarf'` so that debug symbols are produced in our executable, for easier debugging with `lldb`.