### PR TITLE
Replace `ResourceManager` Exception Handlers

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -578,18 +578,22 @@ void GetIndString(Str255 out, int16_t res_id, uint16_t index) {
     auto res = rm.get_resource(ResourceDASM::RESOURCE_TYPE_STRN, res_id);
     if (res == nullptr) {
       out[0] = 0;
+      resError = resNotFound;
       return;
     }
     auto decoded = ResourceDASM::ResourceFile::decode_STRN(res->source_res);
     const auto& str = decoded.strs.at(index);
     if (str.size() > 0xFF) {
+      resError = resNotFound;
       out[0] = 0; // This should be impossible; the STR# format has a single-byte size field per string
     } else {
       out[0] = str.size();
       memcpy(&out[1], str.data(), str.size());
       memset(&out[str.size() + 1], 0, 0xFF - str.size());
+      resError = noErr;
     }
   } catch (const std::out_of_range&) {
+    resError = resNotFound;
     out[0] = 0;
   }
 }


### PR DESCRIPTION
With the additional resource fork files successfully loaded up by the work in #28 , it seems that the logic for progressively searching through opened resource files wasn't quite working correctly. When trying to diagnose and fix it, I was having a hard time navigating through the exception handler-based logic, where we `catch` the `std::out_of_range` errors from the unordered map lookups in order to determine that the currently searched ResourceManager::File does not contain the resource. So, I decided to replace it with more standard control flow techniques, returning `nullptr` in cases where a given file doesn't have a resource, and only `throw`ing an exception when we've searched through all opened resource files and failed to find the resource. Let me know if you disagree with this refactor!

I'm not sure what exactly the problem was, but when I was stepping through with the debugger, it seemed that the empty `catch(const std::out_of_range&` blocks were not actually catching the exception, causing us to bail from the loop after the first iteration in which we fail to find the resource. So if the resource is actually present in a previous file, we never find it.