### PR TITLE
Fix Pict Resource Loading

### DIFF
--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -64,7 +64,7 @@ PixPatHandle GetPixPat(uint16_t patID) {
   return ret_handle;
 }
 
-PicHandle QuickDraw_get_pict_resource(int16_t id) {
+PicHandle GetPicture(int16_t id) {
   // The GetPicture Mac Classic syscall must return a Handle to a decoded Picture resource,
   // but it must also be the same Handle we use to index loaded Resources in the ResourceManager.
   // Otherwise, subsequent calls to DetachResource or ReleaseResource would fail to find it.

--- a/src/QuickDraw.h
+++ b/src/QuickDraw.h
@@ -72,7 +72,7 @@ typedef CGrafPtr GWorldPtr;
 typedef GrafPort* GrafPtr;
 
 PixPatHandle GetPixPat(uint16_t patID);
-PicHandle QuickDraw_get_pict_resource(int16_t picID);
+PicHandle GetPicture(int16_t picID);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/RealmzCocoa.c
+++ b/src/RealmzCocoa.c
@@ -181,10 +181,6 @@ Boolean GetNextEvent(uint16_t eventMask, EventRecord* theEvent) {
   return FALSE;
 }
 
-PicHandle GetPicture(uint16_t picID) {
-  return QuickDraw_get_pict_resource(picID);
-}
-
 void GetPort(GrafPtr* port) {
 }
 

--- a/src/RealmzCocoa.h
+++ b/src/RealmzCocoa.h
@@ -293,7 +293,6 @@ int16_t FindWindow(Point thePoint, WindowPtr* theWindow);
 void DrawDialog(DialogPtr theDialog);
 void TextSize(uint16_t size);
 void BackColor(uint32_t color);
-PicHandle GetPicture(uint16_t picID);
 void DrawPicture(PicHandle myPicture, const Rect* dstRect);
 void PenPixPat(PixPatHandle ppat);
 GDHandle GetGDevice(void);

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -89,7 +89,7 @@ uint16_t WindowManager_get_ditl_resources(int16_t ditlID, DialogItem** items) {
       case 64: {
         ditlData.read(1); // reserved
         uint16_t pictID = ditlData.get_u16b();
-        auto p = QuickDraw_get_pict_resource(pictID);
+        auto p = GetPicture(pictID);
         (*items)[i].type = (*items)[i].DIALOG_ITEM_TYPE_PICT;
         (*items)[i].dialogItem.pict.dispRect = dispWindow;
         (*items)[i].dialogItem.pict.enabled = enabled;


### PR DESCRIPTION
We need the `GetPicture` call to return the same `Handle` that we use to index the PICT resource in the ResourceManager.  However, the `QuickDraw_get_pict_resource` was returning a copied `struct Picture` directly, and `GetPicture` was doing another copy to return a Handle to it. This meant that subsequent calls to functions like `ReleaseResource` using this re-fabricated Handle would fail to find the original PICT resource.

We can't simply return the `Resource.data_handle`, because by default the ResourceManager just fills that with a copy of the raw bytes of the resource, and we need it to be a handle to a usable `Picture`. So, I propose we replace those raw bytes in `data_handle` with the decoded `Picture` object.