### PR TITLE
Menu Activation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ set(SOURCES
     src/realmz_orig/wear.c
     src/macos/MenuController.mm
     src/RealmzCocoa.c
+    src/EventManager.cpp
     src/FileManager.cpp
     src/MemoryManager.cpp
     src/MenuManager.cpp

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -1,0 +1,27 @@
+#include "EventManager.h"
+
+#include <queue>
+
+static std::queue<EventRecord> event_queue;
+
+void PushMenuEvent(int16_t menu_id, int16_t item_id) {
+  Point where = {static_cast<int16_t>(-menu_id), static_cast<int16_t>(-item_id)};
+  EventRecord event = {
+      mouseDown,
+      0,
+      0,
+      where,
+      0};
+  event_queue.push(event);
+}
+
+Boolean GetNextEvent(uint16_t eventMask, EventRecord* theEvent) {
+  if (event_queue.empty()) {
+    theEvent->what = nullEvent;
+    return false;
+  }
+
+  *theEvent = event_queue.front();
+  event_queue.pop();
+  return true;
+}

--- a/src/EventManager.h
+++ b/src/EventManager.h
@@ -19,6 +19,13 @@
 #define app2Evt 259
 #define app3Evt 260
 
+#define inMenuBar 1
+#define inSysWindow 2
+#define inContent 3
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef struct {
   uint16_t what;
   uint32_t message;
@@ -26,3 +33,10 @@ typedef struct {
   Point where;
   uint16_t modifiers;
 } EventRecord;
+
+void PushMenuEvent(int16_t menu_id, int16_t item_id);
+Boolean GetNextEvent(uint16_t eventMask, EventRecord* theEvent);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -1,4 +1,5 @@
 #include "MenuManager.hpp"
+#include "EventManager.h"
 #include "MemoryManager.hpp"
 #include "MenuManager-C-Interface.h"
 #include "ResourceManager.h"
@@ -9,9 +10,9 @@
 #include <resource_file/ResourceFile.hh>
 #include <stdexcept>
 
-static phosg::PrefixedLogger mm_log("[MenuManager] ");
-
 using ResourceDASM::ResourceFile;
+
+static phosg::PrefixedLogger mm_log("[MenuManager] ");
 
 class MenuManager {
 public:
@@ -78,7 +79,7 @@ public:
 
   void sync(void) {
     if (this->cur_menu_list != nullptr) {
-      MCSync(this->cur_menu_list);
+      MCSync(this->cur_menu_list, &PushMenuEvent);
     }
   }
 
@@ -163,7 +164,10 @@ void SetMenuItemText(MenuHandle theMenu, uint16_t item, ConstStr255Param itemStr
 }
 
 int32_t MenuSelect(Point startPt) {
-  return 0;
+  int16_t menu_id = -startPt.v;
+  int16_t item_id = -startPt.h;
+  mm_log.info("Clicked menu %d, item %d", menu_id, item_id);
+  return (static_cast<int32_t>(menu_id) << 16) + item_id;
 }
 
 void DisableItem(MenuHandle theMenu, uint16_t item) {

--- a/src/RealmzCocoa.c
+++ b/src/RealmzCocoa.c
@@ -146,10 +146,6 @@ CWindowPtr GetNewCWindow(int16_t res_id, void* wStorage, WindowPtr behind) {
   return WindowManager_CreateNewWindow(res_id, false, behind);
 }
 
-Boolean GetNextEvent(uint16_t eventMask, EventRecord* theEvent) {
-  return FALSE;
-}
-
 void HLockHi(Handle h) {
 }
 
@@ -174,11 +170,11 @@ Boolean DialogSelect(const EventRecord* theEvent, DialogPtr* theDialog, short* i
 }
 
 int16_t HiWord(int32_t x) {
-  return 0;
+  return (int16_t)(x >> 16);
 }
 
 int16_t LoWord(int32_t x) {
-  return 0;
+  return (int16_t)(x & 0xFFFF);
 }
 
 void SetPt(Point* pt, int16_t h, int16_t v) {
@@ -193,6 +189,9 @@ int32_t MenuKey(int16_t ch) {
 }
 
 int16_t FindWindow(Point thePoint, WindowPtr* theWindow) {
+  if (thePoint.v < 0 && thePoint.h < 0) {
+    return inMenuBar;
+  }
   return 0;
 }
 
@@ -284,6 +283,7 @@ Boolean PtInRect(Point pt, const Rect* r) {
 }
 
 void ExitToShell(void) {
+  exit(EXIT_SUCCESS);
 }
 
 void LocalToGlobal(Point* pt) {

--- a/src/RealmzCocoa.h
+++ b/src/RealmzCocoa.h
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "EventManager.h"
 #include "FileManager.h"
 #include "MemoryManager.h"
 #include "MenuManager-C-Interface.h"
@@ -107,10 +108,6 @@ static inline void rintel2moto(Rect* r) {
 #define kControlPageUpPart 22
 #define kControlPageDownPart 23
 #define kControlIndicatorPart 129
-
-#define inMenuBar 1
-#define inSysWindow 2
-#define inContent 3
 
 #define resNotFound -192
 
@@ -243,7 +240,6 @@ int32_t DragGrayRgn(RgnHandle theRgn, Point startPt, const Rect* boundsRect, con
     int16_t axis, Ptr actionProc);
 void ParamText(ConstStr255Param param0, ConstStr255Param param1, ConstStr255Param param2, ConstStr255Param param3);
 void SystemTask(void);
-Boolean GetNextEvent(uint16_t eventMask, EventRecord* theEvent);
 void DisposeDialog(DialogPtr theDialog);
 void ExitToShell(void);
 OSErr SetDepth(GDHandle aDevice, uint16_t depth, uint16_t whichFlags, uint16_t flags);

--- a/src/macos/MenuController.h
+++ b/src/macos/MenuController.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-void MCSync(std::shared_ptr<MenuList> menuList);
+void MCSync(std::shared_ptr<MenuList> menuList, void (*callback)(int16_t, int16_t));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I've set up a system where the MenuManager registers a callback with the MenuController. When a menu item is selected, the menu and item id (from the MENU resource) are sent to the callback. The callback then manufactures a `mousedown` event. Normally, it looks like Realmz takes the Point stored in the event and passes it to `FindWindow`, which determines which window the mouse clicked. If it's in the menu bar, it returns `inMenuBar`, and Realmz passes the Point to `MenuSelect` to determine which menu was clicked.

Luckily, we don't have to implement these routines to do this, because AppKit already knows which menu item was clicked. I've attached the menu and item ids to each menu item so that, in my click handler, I can extract these ids and pass them to the callback. And in order to differentiate between regular mousedown events and the ones manufactured by the MenuManager, I figured that I could re-use the `where` attribute of the event, the Point data, to store the menu and item ids. Since negative values in `where` would be invalid because they would map offscreen, I figured I could just store the ids as negative numbers, then implement `FindWindow` to look for these negative numbers to know when to return `inMenuBar`. From there, I just had to construct the `int32` with the menu id in the high word and the item id in the low word so that the huge switch tree in `HandleMenuChoice` can unpack it and take the appropriate action.

Finally, with the menu click callback working, I figured the first order of business would be to make sure File > Quit works, so I prioritized some fixes to get that working.

This will probably conflict with your input handling work, but I needed a way to queue up these fake menu events and pull them off the queue when Realmz' main loop calls `GetNextEvent`. We can resolve the conflict and merge my menu work into your event handling