### PR TITLE
fix memory corruption during InitGraf

### DIFF
--- a/src/QuickDraw.h
+++ b/src/QuickDraw.h
@@ -88,8 +88,10 @@ typedef struct {
   RGBColor rgbBgColor;
 } CGrafPort;
 typedef CGrafPort* CGrafPtr;
+typedef CGrafPort** CGrafHandle; // Not part of Classic Mac OS API
 typedef CGrafPtr GWorldPtr;
 typedef GrafPort* GrafPtr;
+typedef GrafPort** GrafHandle; // Not part of Classic Mac OS API
 
 typedef struct {
   PixMap iconPMap;
@@ -100,7 +102,20 @@ typedef struct {
 } CIcon;
 typedef CIcon *CIconPtr, **CIconHandle;
 
-void InitGraf(void* globalPtr);
+typedef struct {
+  CGrafPtr thePort;
+  BitMap screenBits;
+
+  // We internally allocate a handle for thePort, even though thePort itself is
+  // not a handle, so we store the handle here. This is not part of the Classic
+  // Mac OS API - they didn't intend for GrafPorts to be relocatable, but we
+  // never relocate handles anyway.
+  CGrafHandle default_graf_handle;
+} QuickDrawGlobals;
+
+// Note: Technically the argument to InitGraf is a void*, but we type it here
+// for better safety.
+void InitGraf(QuickDrawGlobals* globalPtr);
 void SetPort(CGrafPtr port);
 void GetPort(GrafPtr* port);
 PixPatHandle GetPixPat(uint16_t patID);

--- a/src/RealmzCocoa.h
+++ b/src/RealmzCocoa.h
@@ -196,11 +196,6 @@ typedef struct {
 typedef DialogRecord* DialogPeek;
 
 typedef struct {
-  GrafPtr thePort;
-  BitMap screenBits;
-} QuickDrawGlobals;
-
-typedef struct {
   Boolean good;
   Str63 fName;
   int16_t vRefNum;
@@ -395,7 +390,6 @@ void SFPutFile(Point where, const Str255 prompt, const Str255 origName, Ptr dlgH
 OSErr GetProcessInformation(const ProcessSerialNumber* PSN, ProcessInfoRecPtr info);
 ControlHandle NewControl(WindowPtr theWindow, const Rect* boundsRect, ConstStr255Param title, Boolean visible,
     int16_t value, int16_t min, int16_t max, int16_t procID, int32_t refCon);
-void InitGraf(void* globalPtr);
 void InitWindows(void);
 
 #define cmdKey 256


### PR DESCRIPTION
The gist of it is that InitGraf takes a pointer to the QuickDrawGlobals structure, but we were treating it as a pointer to a CGrafPort instead (which is understandable since the first element in QuickDrawGlobals is a CGrafPort pointer). THe globals struct is smaller than CGrafPort, however, so this meant we would write to other global variables in the global memory space.
