### PR TITLE
Basic Editable Text

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -343,7 +343,6 @@ protected:
     ev.modifiers = this->modifier_flags;
     ev.sdl_window_id = sdl_window_id;
     if (text && strlen(text)) {
-      ev.text = (char*)malloc(strlen(text) + 1);
       strcpy(ev.text, text);
     }
   }

--- a/src/EventManager.h
+++ b/src/EventManager.h
@@ -70,7 +70,7 @@ typedef struct {
 
   // The following fields are not part of the original Classic Mac OS API
   uint32_t sdl_window_id;
-  char* text;
+  char text[32];
 } EventRecord;
 
 uint8_t mac_vk_from_message(uint32_t message);

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -648,7 +648,7 @@ public:
     }
   }
 
-  void handle_text_input(char* text, std::shared_ptr<DialogItem> item) {
+  void handle_text_input(const std::string& text, std::shared_ptr<DialogItem> item) {
     item->append_text(text);
     render();
   }

--- a/src/realmz_orig/structs.h
+++ b/src/realmz_orig/structs.h
@@ -15,8 +15,7 @@ typedef struct {
   char auto256, iteminfo, autoweapswitch, nomusic, usenpc, castonfriends, allowfumble, allowunique;
   short defaultfont;
   int32_t serial;
-  // Str255 name_str;
-  char name_str[1]; // TODO: Figure out how to load serialized Pascal strings
+  Str255 name_str;
   char autonote, portraitchoice, currentscenariohold, blank3;
   short journalindex2, blank5, blank6, blank7, blank8, blank9, blank10;
 } PrefRecord, *PrefPtr, **PrefHandle;


### PR DESCRIPTION
This PR introduces a rudimentary implementation of the EDIT_TEXT dialog item type. It uses SDL's [text input functions](https://wiki.libsdl.org/SDL3/SDL_StartTextInput) together with the EventManager's keydown events to allow inputting text and deleting characters from the end of the text input. More advanced text editing, such as cursor movement and rendering, highlighting, and proper unicode support, will be implemented in future PRs.

This required changing how dialog windows are rendered. Instead of simply rendering each dialog item in order, we must delay rendering static and editable text items until after all other dialog items and controls are rendered. This is to match the behavior described in Inside Macintosh, under the `DrawDialog` description:

> The DrawDialog procedure draws the entire contents of the specified dialog box. The
DrawDialog procedure draws all dialog items, calls the Control Manager procedure
DrawControls to draw all controls, and calls the TextEdit procedure TEUpdate to
update all static and editable text items and to draw their display rectangles. The
DrawDialog procedure also calls the application-defined items’ draw procedures if
the items’ rectangles are within the update region.
> - _Inside Macintosh: Macintosh Toolbox Essentials_, 6-142