### PR TITLE
Fix stuck movement bug

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -296,6 +296,10 @@ public:
     this->event_queue.emplace_back(EventRecord{mouseDown, 0, 0, where, 0});
   }
 
+  void reset_mouse_state() {
+    this->modifier_flags |= EVMOD_MOUSE_BUTTON_UP;
+  }
+
   inline const Point& get_mouse_loc() const {
     return this->mouse_loc;
   }
@@ -488,4 +492,8 @@ Boolean StillDown(void) {
 
 void PushMenuEvent(int16_t menu_id, int16_t item_id) {
   em.push_menu_event(menu_id, item_id);
+}
+
+void reset_mouse_state() {
+  em.reset_mouse_state();
 }

--- a/src/EventManager.h
+++ b/src/EventManager.h
@@ -91,6 +91,8 @@ void FlushEvents(int16_t mask, uint16_t stop_mask); // IM2-69
 
 Boolean WaitNextEvent(int16_t mask, EventRecord* ev, uint32_t sleep, RgnHandle mouse_rgn);
 
+void reset_mouse_state();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -980,6 +980,14 @@ public:
       throw std::logic_error("Attempted to delete nonexistent window");
     }
 
+    // When the window is dismissed via a mousedown, the enqueued mouseup event is either
+    // lost when the window is destroyed, or the button is not released in time for it to be
+    // handled by the window. It's not clear why the mouseup event isn't handled by the surviving
+    // window. In any case, we can simply reset the mouse state to prevent the StillDown function
+    // from thinking that the mouse button is still pressed.
+    // TODO: figure out a better way of handling this.
+    reset_mouse_state();
+
     sdl_window_id_to_window.erase(window_it->second->sdl_window_id());
     record_to_window.erase(window_it);
 


### PR DESCRIPTION
You were on the right track with your observation that the mouseup event might have been handled by a different window, though in fact I confirmed that we weren't seeing the mouseup event at all when you close the party select screen. It looks like SDL windows each have their own event queue. When a button is clicked that closes and destroys the window, either:

  1. the user managed to release the mouse button quickly enough that the mouseup
     event is enqueued, but it gets destroyed and skipped when the application destroys
     the window during handling of the mousedown event, or,
  2. the user did not release the mouse button before the window was destroyed.

In the second case, it appears the mouseup event is missed. Perhaps SDL keeps track
of which window the mousedown event occurs in, and does not create an event if the next
mouseup happens in a different window? Whatever the reason, we can temporarily mitigate
this by manually resetting the mouse state. It's not a great solution, but it works.

To me, this is more evidence that we should implement our own virtual window system, so that we can have a single SDL window within which we'll have the freedom to arrange and order the Realmz windows as we like, and so that we can have a centralized event queue processing all events occurring on any virtual window. I don't think we're too far away from it, given the recent refactoring work I did with the `GraphicsCanvas`. Eager to discuss more at our meeting tonight!