### PR TITLE
Pen Size and Pattern Transfer Mode Drawing

### DIFF
--- a/src/GraphicsCanvas.cpp
+++ b/src/GraphicsCanvas.cpp
@@ -412,10 +412,36 @@ int GraphicsCanvas::measure_text(const std::string& text) {
   return ::draw_text(renderer.get(), text, 0, 0, port->txFont, port->txSize, port->txFace, port->rgbFgColor);
 }
 
+void GraphicsCanvas::draw_pen(SDL_Renderer* renderer, int x, int y) {
+  auto [height, width] = port->pnSize;
+  for (int i{0}; i < width; i++) {
+    for (int j{0}; j < height; j++) {
+      SDL_RenderPoint(renderer, x + i, y + j);
+    }
+  }
+}
+
 void GraphicsCanvas::draw_rect(const Rect& dispRect) {
   auto renderer = start_draw();
-  auto dest = sdl_frect(dispRect);
-  SDL_RenderRect(renderer, &dest);
+
+  float rect_width = dispRect.right - dispRect.left;
+  float rect_height = dispRect.bottom - dispRect.top;
+
+  auto [height, width] = port->pnSize;
+
+  SDL_FRect rect;
+
+  for (int i{0}; i < width; i++) {
+    for (int j{0}; j < height; j++) {
+      rect = {
+          .x = static_cast<float>(dispRect.left + i),
+          .y = static_cast<float>(dispRect.top + j),
+          .w = rect_width,
+          .h = rect_height,
+      };
+      SDL_RenderRect(renderer, &rect);
+    }
+  }
   end_draw();
 }
 
@@ -451,20 +477,20 @@ void GraphicsCanvas::draw_oval(const Rect& dispRect) {
 
   // Foci
   // if (vertical) {
-  //   SDL_RenderPoint(renderer, x0, y0 + c);
-  //   SDL_RenderPoint(renderer, x0, y0 - c);
+  //   draw_pen(renderer, x0, y0 + c);
+  //   draw_pen(renderer, x0, y0 - c);
   // } else {
-  //   SDL_RenderPoint(renderer, x0 + c, y0);
-  //   SDL_RenderPoint(renderer, x0 - c, y0);
+  //   draw_pen(renderer, x0 + c, y0);
+  //   draw_pen(renderer, x0 - c, y0);
   // }
 
   int dx_f1{}, dx_f2{}, dy_f1{}, dy_f2{};
   while (x > 0) {
     // Mirror the pixel to quadrants 2, 3, and 4
-    SDL_RenderPoint(renderer, x0 + x, y0 + y);
-    SDL_RenderPoint(renderer, x0 + x, y0 - y);
-    SDL_RenderPoint(renderer, x0 - x, y0 + y);
-    SDL_RenderPoint(renderer, x0 - x, y0 - y);
+    draw_pen(renderer, x0 + x, y0 + y);
+    draw_pen(renderer, x0 + x, y0 - y);
+    draw_pen(renderer, x0 - x, y0 + y);
+    draw_pen(renderer, x0 - x, y0 - y);
 
     // Search next point to draw, starting with y+1, then y+1 and x-1, then
     // just x-1. The first one that is inside the bounds of the ellipse is our
@@ -509,11 +535,11 @@ void GraphicsCanvas::draw_oval(const Rect& dispRect) {
 
   // Draw one final pixel at (0, [a|b]) and (0, [-a|-b])
   if (vertical) {
-    SDL_RenderPoint(renderer, x0, y0 + a);
-    SDL_RenderPoint(renderer, x0, y0 - a);
+    draw_pen(renderer, x0, y0 + a);
+    draw_pen(renderer, x0, y0 - a);
   } else {
-    SDL_RenderPoint(renderer, x0, y0 + b);
-    SDL_RenderPoint(renderer, x0, y0 - b);
+    draw_pen(renderer, x0, y0 + b);
+    draw_pen(renderer, x0, y0 - b);
   }
 
   end_draw();

--- a/src/GraphicsCanvas.hpp
+++ b/src/GraphicsCanvas.hpp
@@ -84,6 +84,7 @@ public:
   // Uses the GraphicsCanvas' port settings to draw the specified text to a dummy renderer and
   // return its rendered width in pixels.
   int measure_text(const std::string& text);
+  void draw_pen(SDL_Renderer* renderer, int x, int y);
   void draw_rect(const Rect& dispRect);
   void draw_oval(const Rect& dispRect);
   void draw_line(const Point& start, const Point& end);

--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -30,7 +30,9 @@ static std::unordered_map<CGrafPtr, std::shared_ptr<GraphicsCanvas>> canvas_look
 // Originally declared in variables.h. It seems that `qd` was introduced by Myriad during the
 // port to PC in place of Classic Mac's global QuickDraw context. We can repurpose it here
 // for easier access in our code, while still exposing a C-compatible struct.
-QuickDrawGlobals qd{};
+QuickDrawGlobals qd{
+    .defaultPort = {
+        .pnSize = {.v = 1, .h = 1}}};
 
 Rect rect_from_reader(phosg::StringReader& data) {
   Rect r;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -925,21 +925,9 @@ WindowPtr WindowManager::create_window(
     std::vector<std::shared_ptr<DialogItem>>&& dialog_items) {
   CGrafPtr current_port = qd.thePort;
 
-  CGrafPort port{};
-  port.portRect = bounds;
-
   CWindowRecord* wr = new CWindowRecord();
-  wr->port = port;
+  memcpy(&wr->port, current_port, sizeof(CGrafPort));
   wr->port.portRect = bounds;
-  wr->port.txFont = current_port->txFont;
-  wr->port.txFace = current_port->txFace;
-  wr->port.txMode = current_port->txMode;
-  wr->port.txSize = current_port->txSize;
-
-  wr->port.fgColor = current_port->fgColor;
-  wr->port.bgColor = current_port->bgColor;
-  wr->port.rgbFgColor = current_port->rgbFgColor;
-  wr->port.rgbBgColor = current_port->rgbBgColor;
 
   // Note: Realmz doesn't actually use any of the following fields; we also
   // don't use numItems and dItems internally here (we instead use the vector

--- a/src/tests/GraphicsTest.cpp
+++ b/src/tests/GraphicsTest.cpp
@@ -29,6 +29,8 @@ int main() {
   // parameters when creating new windows.
   InitGraf(&qd);
 
+  qd.thePort->pnSize = {.v = 4, .h = 4};
+
   wm.init();
 
   auto bounds = Rect{0, 0, WINDOW_HEIGHT, WINDOW_WIDTH};


### PR DESCRIPTION
Enables support for arbitrary pen size and pattern drawing.

The apparent intention of the Realmz code conflicts with the actual described behavior in Inside Macintosh. See `booty.c` lines 1592-1615 for an example.

Realmz appears to call the `PenMode` procedure with only two source modes, `PenMode(0)` (`srcCopy`) and `PenMode(2)` (`srcXor`). However, the description of `PenMode` in Imaging With Quickdraw (3-46) seems to imply that these have no effect:

> If you specify a source mode (such as one used with the CopyBits procedure) instead of
a pattern mode, no drawing is performed.

The "pattern modes" are described on page 3-45, and are constants in the range of 8-15. The "source modes" described on page 4-107 as ranging from 0-7. So, it would appear that calling `PenMode` with 0 and 2 leads to no drawing.

However, a little later down on page 3-46, under the "Special Considerations" heading, it mentions:

> When your application draws with a pixel pattern, Color QuickDraw ignores the pattern
mode and simply transfers the pattern directly to the pixel map without regard to the
foreground and background colors.

This is re-affirmed on page 4-23, under "Drawing with Pixel Patterns":

> Because a pixel pattern already contains color, Color QuickDraw ignores
the foreground and background colors when your application uses these
routines to draw with a pixel pattern. Color QuickDraw also ignores the
pen mode by drawing the pixel pattern directly onto the pixel image.

So, it would seem that all of Realmz' manipulation of the pen mode and the foreground and background colors in places like `booty.c` are irrelevant, as long as a pixel pattern is set.

When drawing with a pixel pattern, QuickDraw always renders the pattern relative to the origin:

> So that adjacent areas of the same pattern form a continuous, coordinated pattern, all
patterns are always drawn relative to the origin of the graphics port.
> Imaging With Quickdraw (3-6)

To support this and to simplify our implementation, I've set up some pre-rendered canvases with each pixel pattern resource that is loaded. The canvases should be large enough to cover any window size that Realmz uses. When a draw call is made while the pattern is set as the pen's pattern, we can simply copy pixels from the pre-rendered canvas to the destination canvas, with any source modes applied.

Imaging With Quickdraw (4-33) on the color pattern drawing algorithm:

> When you use the srcCopy mode to transfer a pixel into a pixel map, Color QuickDraw
determines how close the color of that pixel is to black, and then assigns this relative
amount of foreground color to the destination pixel. Color QuickDraw also determines
how close the color of that pixel is to white, and assigns this relative amount of
background color to the destination pixel.
> To accomplish this, Color QuickDraw first multiplies the relative intensity of each red,
green, and blue component of the source pixel by the corresponding value of the
red, green, or blue component of the foreground color. It then multiplies the relative
intensity of each red, green, and blue component of the source pixel by the
corresponding value of the red, green, or blue component of the background color. For
each component, Color QuickDraw adds the results and then assigns the new result as
the value for the destination pixel’s corresponding component.

