### PR TITLE
replace deprecated phosg functions with standard equivalents

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -360,7 +360,7 @@ protected:
         break;
       case SDL_EVENT_KEY_DOWN:
       case SDL_EVENT_KEY_UP: {
-        em_log.info("%s mod=%04hX key=%08" PRIX32,
+        em_log.info_f("{} mod={:04X} key={:08X}",
             (e.type == SDL_EVENT_KEY_UP) ? "SDL_EVENT_KEY_UP" : "SDL_EVENT_KEY_DOWN",
             e.key.mod, e.key.key);
         this->set_modifier_value(EVMOD_RIGHT_CONTROL_KEY_DOWN, e.key.mod & SDL_KMOD_RCTRL);
@@ -376,7 +376,7 @@ protected:
         if (message != 0) {
           this->enqueue_event((e.type == SDL_EVENT_KEY_DOWN) ? keyDown : keyUp, message, e.key.windowID, "");
         } else {
-          em_log.warning("Unknown key pressed: key=0x%zX scancode=0x%zX",
+          em_log.warning_f("Unknown key pressed: key=0x{:X} scancode=0x{:X}",
               static_cast<size_t>(e.key.key), static_cast<size_t>(e.key.scancode));
         }
         break;
@@ -389,7 +389,7 @@ protected:
         break;
       case SDL_EVENT_MOUSE_BUTTON_DOWN:
       case SDL_EVENT_MOUSE_BUTTON_UP:
-        em_log.info("%s %hhu %hhu %g %g",
+        em_log.info_f("{} {} {} {:g} {:g}",
             (e.type == SDL_EVENT_MOUSE_BUTTON_UP) ? "SDL_EVENT_MOUSE_BUTTON_UP" : "SDL_EVENT_MOUSE_BUTTON_DOWN",
             e.button.button, e.button.clicks, e.button.x, e.button.y);
         // Ignore events for all mouse buttons except the primary (left) button
@@ -402,7 +402,7 @@ protected:
         break;
       case SDL_EVENT_TEXT_EDITING:
       case SDL_EVENT_TEXT_INPUT:
-        em_log.info("%s %s",
+        em_log.info_f("{} {}",
             (e.type == SDL_EVENT_TEXT_EDITING) ? "SDL_EVENT_TEXT_EDITING" : "SDL_EVENT_TEXT_INPUT", e.text.text);
 
         // We can use the otherwise unused app4Evt to signal a text input event, the handling of which
@@ -410,7 +410,7 @@ protected:
         this->enqueue_event(app4Evt, 0, e.text.windowID, e.text.text);
         break;
       default:
-        em_log.info("Unhandled SDL event type 0x%" PRIX32, e.type);
+        em_log.info_f("Unhandled SDL event type 0x{:X}", e.type);
     }
   }
 
@@ -444,7 +444,7 @@ void FlushEvents(int16_t which_mask, uint16_t stop_mask) {
   // Realmz only calls this with which_mask = everyEvent and stop_mask = 0, so
   // we don't bother to implement filtering.
   if (which_mask != everyEvent) {
-    throw std::logic_error(phosg::string_printf("which_mask (%04hX) masks out some events in FlushEvents", which_mask));
+    throw std::logic_error(std::format("which_mask ({:04X}) masks out some events in FlushEvents", which_mask));
   }
   if (stop_mask != 0) {
     throw std::logic_error("stop_mask specifies some events");
@@ -457,7 +457,7 @@ Boolean GetNextEvent(int16_t which_mask, EventRecord* ret) {
   // Realmz only calls this with which_mask = everyEvent, so we don't bother to
   // implement filtering.
   if (which_mask != everyEvent) {
-    throw std::logic_error(phosg::string_printf("which_mask (%04hX) masks out some events in GetNextEvent", which_mask));
+    throw std::logic_error(std::format("which_mask ({:04X}) masks out some events in GetNextEvent", which_mask));
   }
 
   *ret = em.get_next_event(0);
@@ -468,7 +468,7 @@ Boolean WaitNextEvent(int16_t which_mask, EventRecord* ret, uint32_t sleep, RgnH
   // Realmz doesn't use mask, sleep, or mouse_rgn (thankfully, since mouse_rgn
   // would be annoying to implement!)
   if (which_mask != everyEvent) {
-    throw std::logic_error(phosg::string_printf("which_mask (%04hX) masks out some events in WaitNextEvent", which_mask));
+    throw std::logic_error(std::format("which_mask ({:04X}) masks out some events in WaitNextEvent", which_mask));
   }
   if (mouse_rgn) {
     throw std::logic_error("mouse_rgn must be null");

--- a/src/GraphicsCanvas.cpp
+++ b/src/GraphicsCanvas.cpp
@@ -60,7 +60,7 @@ bool render_surface(SDL_Renderer* sdlRenderer, SDL_Surface* surface, const Rect&
   auto texture = SDL_CreateTextureFromSurface(sdlRenderer, surface);
 
   if (!texture) {
-    canvas_log.error("Could not render surface: %s", SDL_GetError());
+    canvas_log.error_f("Could not render surface: {}", SDL_GetError());
     return false;
   }
 
@@ -74,10 +74,10 @@ bool render_surface(SDL_Renderer* sdlRenderer, SDL_Surface* surface, const Rect&
   SDL_FRect src_rect = {0, 0, text_dest.w, text_dest.h};
 
   if (!text_texture) {
-    canvas_log.error("Failed to create texture when rendering text: %s", SDL_GetError());
+    canvas_log.error_f("Failed to create texture when rendering text: {}", SDL_GetError());
     return false;
   } else if (!SDL_RenderTexture(sdlRenderer, text_texture.get(), &src_rect, &text_dest)) {
-    canvas_log.error("Failed to render text texture: %s", SDL_GetError());
+    canvas_log.error_f("Failed to render text texture: {}", SDL_GetError());
     return false;
   }
   return true;
@@ -86,12 +86,12 @@ bool render_surface(SDL_Renderer* sdlRenderer, SDL_Surface* surface, const Rect&
 void draw_rgba_picture(std::shared_ptr<SDL_Renderer> sdlRenderer, void* pixels, int w, int h, const Rect& rect) {
   auto s = sdl_make_unique(SDL_CreateSurfaceFrom(w, h, SDL_PIXELFORMAT_RGBA32, pixels, 4 * w));
   if (!s) {
-    canvas_log.error("Could not create surface: %s\n", SDL_GetError());
+    canvas_log.error_f("Could not create surface: {}", SDL_GetError());
     return;
   }
   auto t = sdl_make_unique(SDL_CreateTextureFromSurface(sdlRenderer.get(), s.get()));
   if (!t) {
-    canvas_log.error("Could not create texture: %s\n", SDL_GetError());
+    canvas_log.error_f("Could not create texture: {}", SDL_GetError());
     return;
   }
   SDL_FRect dest;
@@ -117,7 +117,7 @@ bool draw_text_ttf(
   auto text_surface = sdl_make_unique(TTF_RenderText_Blended_Wrapped(
       font, processed_text.data(), processed_text.size(), color, rect.right - rect.left + 50));
   if (!text_surface) {
-    canvas_log.error("Failed to create surface when rendering text: %s", SDL_GetError());
+    canvas_log.error_f("Failed to create surface when rendering text: {}", SDL_GetError());
     return false;
   } else {
     return render_surface(sdlRenderer, text_surface.get(), rect);
@@ -130,7 +130,7 @@ bool render_img(SDL_Renderer* sdlRenderer, const phosg::Image& img, const Rect& 
   auto surface = sdl_make_unique(SDL_CreateSurfaceFrom(
       w, h, SDL_PIXELFORMAT_RGBA32, const_cast<void*>(img.get_data()), 4 * img.get_width()));
   if (!surface) {
-    canvas_log.error("Failed to create surface when rendering text: %s", SDL_GetError());
+    canvas_log.error_f("Failed to create surface when rendering text: {}", SDL_GetError());
     return false;
   } else {
     return render_surface(sdlRenderer, surface.get(), rect);
@@ -206,7 +206,7 @@ int draw_text(
     return width;
   }
 
-  canvas_log.error("No renderer is available for font %hd; cannot render text \"%s\"", font_id, text.c_str());
+  canvas_log.error_f("No renderer is available for font {}; cannot render text \"{}\"", font_id, text);
   return -1;
 }
 
@@ -285,7 +285,7 @@ bool GraphicsCanvas::init() {
           height));
 
   if (sdlTexture.get() == nullptr) {
-    canvas_log.error("Could not create SDL_Texture: %s", SDL_GetError());
+    canvas_log.error_f("Could not create SDL_Texture: {}", SDL_GetError());
     return false;
   }
 
@@ -347,7 +347,7 @@ void GraphicsCanvas::draw_rgba_picture(void* pixels, int w, int h, const Rect& r
 
   auto s = SDL_CreateSurfaceFrom(w, h, SDL_PIXELFORMAT_RGBA32, pixels, 4 * w);
   if (!s) {
-    canvas_log.error("Could not create surface: %s\n", SDL_GetError());
+    canvas_log.error_f("Could not create surface: {}", SDL_GetError());
     return;
   }
 
@@ -386,7 +386,7 @@ bool GraphicsCanvas::draw_text(
   }
 
   if (!success) {
-    canvas_log.error("No renderer is available for font %hd; cannot render text \"%s\"", port->txFont, text.c_str());
+    canvas_log.error_f("No renderer is available for font {}; cannot render text \"{}\"", port->txFont, text);
   }
 
   end_draw();
@@ -545,18 +545,18 @@ void GraphicsCanvas::draw_background(sdl_window_shared sdlWindow, PixPatHandle b
       3 * w));
 
   if (s == nullptr) {
-    canvas_log.error("Could not create surface: %s\n", SDL_GetError());
+    canvas_log.error_f("Could not create surface: {}", SDL_GetError());
     return;
   }
 
   auto t = sdl_make_unique(SDL_CreateTextureFromSurface(renderer, s.get()));
   if (t == nullptr) {
-    canvas_log.error("Could not create texture: %s\n", SDL_GetError());
+    canvas_log.error_f("Could not create texture: {}", SDL_GetError());
     return;
   }
 
   if (!SDL_RenderTextureTiled(renderer, t.get(), NULL, 1.0, NULL)) {
-    canvas_log.error("Could not render background texture: %s", SDL_GetError());
+    canvas_log.error_f("Could not render background texture: {}", SDL_GetError());
   }
 }
 
@@ -575,26 +575,26 @@ void GraphicsCanvas::copy_from(GraphicsCanvas& src, const Rect& srcRect, const R
     auto src_renderer = src.start_draw();
     auto src_surface = sdl_make_unique(SDL_RenderReadPixels(src_renderer, &sr));
     if (!SDL_BlitSurfaceScaled(src_surface.get(), &sr, s.get(), NULL, SDL_SCALEMODE_LINEAR)) {
-      canvas_log.error("Could not blit surface scaled: %s", SDL_GetError());
+      canvas_log.error_f("Could not blit surface scaled: {}", SDL_GetError());
       return;
     }
     src.end_draw();
   } else {
     if (!SDL_BlitSurfaceScaled(src.sdlSurface.get(), &sr, s.get(), NULL, SDL_SCALEMODE_LINEAR)) {
-      canvas_log.error("Could not blit surface scaled: %s", SDL_GetError());
+      canvas_log.error_f("Could not blit surface scaled: {}", SDL_GetError());
       return;
     }
   }
 
   auto t = sdl_make_unique(SDL_CreateTextureFromSurface(renderer, s.get()));
   if (t == nullptr) {
-    canvas_log.error("Could not create_texture: %s", SDL_GetError());
+    canvas_log.error_f("Could not create_texture: {}", SDL_GetError());
     return;
   }
 
   const auto dr = sdl_frect(dstRect);
   if (!SDL_RenderTexture(renderer, t.get(), NULL, &dr)) {
-    canvas_log.error("Could not copy bits: %s", SDL_GetError());
+    canvas_log.error_f("Could not copy bits: {}", SDL_GetError());
   }
 
   end_draw();
@@ -604,20 +604,20 @@ bool GraphicsCanvas::init_renderer() {
   if (sdlWindow) {
     if (!SDL_GetRenderer(sdlWindow.get())) {
       if (!SDL_CreateRenderer(sdlWindow.get(), "opengl")) {
-        canvas_log.error("Could not create window renderer: %s", SDL_GetError());
+        canvas_log.error_f("Could not create window renderer: {}", SDL_GetError());
         return false;
       }
     }
   } else {
     sdlSurface = sdl_make_unique(SDL_CreateSurface(width, height, SDL_PIXELFORMAT_RGBA32));
     if (sdlSurface == nullptr) {
-      canvas_log.error("Could not create SDL_Surface for software rendering: %s", SDL_GetError());
+      canvas_log.error_f("Could not create SDL_Surface for software rendering: {}", SDL_GetError());
       return false;
     }
 
     sdlRenderer = sdl_make_unique(SDL_CreateSoftwareRenderer(sdlSurface.get()));
     if (sdlRenderer == nullptr) {
-      canvas_log.error("Could not create software SDL_Renderer: %s", SDL_GetError());
+      canvas_log.error_f("Could not create software SDL_Renderer: {}", SDL_GetError());
       return false;
     }
   }

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -21,7 +21,7 @@ public:
 
   std::shared_ptr<Menu> get_menu(int16_t res_id) {
     if (!this->res_id_to_menu.contains(res_id)) {
-      mm_log.info("Loading MENU:%d from resource forks", res_id);
+      mm_log.info_f("Loading MENU:{} from resource forks", res_id);
       auto handle = GetResource(ResourceDASM::RESOURCE_TYPE_MENU, res_id);
       auto decoded_menu = ResourceFile::decode_MENU(*handle, GetHandleSize(handle));
       auto menu = std::make_shared<Menu>(Menu(decoded_menu));
@@ -60,7 +60,7 @@ public:
       // to get a handle to the unloaded menu. To try to satisfy that, assume that the
       // resource id of the menu is the same as the given menu id, try loading the menu,
       // and return it.
-      mm_log.warning("Attempted to get menu with ID %d, but it doesn't appear in current MBAR", menu_id);
+      mm_log.warning_f("Attempted to get menu with ID {}, but it doesn't appear in current MBAR", menu_id);
       try {
         this->get_menu(menu_id);
         return this->menu_id_to_handle.at(menu_id);
@@ -112,7 +112,7 @@ private:
 static MenuManager mm;
 
 Handle GetNewMBar(int16_t menuBarID) {
-  mm_log.info("Loading MBAR:%d from resource forks", menuBarID);
+  mm_log.info_f("Loading MBAR:{} from resource forks", menuBarID);
   auto handle = GetResource(ResourceDASM::RESOURCE_TYPE_MBAR, menuBarID);
   mm.load_menu_list(handle);
   return handle;
@@ -133,7 +133,7 @@ void SetMenuBar(Handle menuList) {
 
 void InsertMenu(MenuHandle theMenu, int16_t beforeID) {
   if (beforeID != -1) {
-    mm_log.error("Called InsertMenu on a non sub-menu");
+    mm_log.error_f("Called InsertMenu on a non sub-menu");
     return;
   }
 
@@ -157,7 +157,7 @@ void DeleteMenu(int16_t menuID) {
 void SetMenuItemText(MenuHandle theMenu, uint16_t item, ConstStr255Param itemString) {
   auto menu = mm.get_menu(theMenu);
   if (item > menu->items.size()) {
-    mm_log.info("Tried to set text of menu item %d on menu %s but it only has %lu items", item, menu->title.c_str(), menu->items.size());
+    mm_log.info_f("Tried to set text of menu item {} on menu {} but it only has {} items", item, menu->title, menu->items.size());
     return;
   }
   menu->items.at(item - 1).name = string_for_pstr<256>(itemString);
@@ -166,7 +166,7 @@ void SetMenuItemText(MenuHandle theMenu, uint16_t item, ConstStr255Param itemStr
 int32_t MenuSelect(Point startPt) {
   int16_t menu_id = -startPt.v;
   int16_t item_id = -startPt.h;
-  mm_log.info("Clicked menu %d, item %d", menu_id, item_id);
+  mm_log.info_f("Clicked menu {}, item {}", menu_id, item_id);
   return (static_cast<int32_t>(menu_id) << 16) + item_id;
 }
 
@@ -176,7 +176,7 @@ void DisableItem(MenuHandle theMenu, uint16_t item) {
     menu->enabled = false;
   } else {
     if (item > menu->items.size()) {
-      mm_log.warning("Attempted to disable MENU:%d item %d, but it doesn't exist", menu->menu_id, item);
+      mm_log.warning_f("Attempted to disable MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
     } else {
       menu->items[item - 1].enabled = false;
     }
@@ -189,7 +189,7 @@ void EnableItem(MenuHandle theMenu, uint16_t item) {
     menu->enabled = true;
   } else {
     if (item > menu->items.size()) {
-      mm_log.warning("Attempted to enable MENU:%d item %d, but it doesn't exist", menu->menu_id, item);
+      mm_log.warning_f("Attempted to enable MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
     } else {
       menu->items[item - 1].enabled = true;
     }
@@ -199,7 +199,7 @@ void EnableItem(MenuHandle theMenu, uint16_t item) {
 void CheckItem(MenuHandle theMenu, uint16_t item, Boolean checked) {
   auto menu = mm.get_menu(theMenu);
   if (item > menu->items.size()) {
-    mm_log.warning("Attempted to (un)check MENU:%d item %d, but it doesn't exist", menu->menu_id, item);
+    mm_log.warning_f("Attempted to (un)check MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
   } else {
     menu->items.at(item - 1).checked = checked;
   }

--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -62,7 +62,7 @@ RGBColor color_const_to_rgb(int32_t color_const) {
     case blueColor:
       return RGBColor{0, 0, 65535};
     default:
-      qd_log.error("Unrecognized color constant %d", color_const);
+      qd_log.error_f("Unrecognized color constant {}", color_const);
       break;
   }
   return RGBColor{};
@@ -76,7 +76,7 @@ void deregister_canvas(std::shared_ptr<GraphicsCanvas> canvas) {
   try {
     canvas_lookup.erase(canvas->get_port());
   } catch (std::out_of_range) {
-    qd_log.error("Tried to delete canvas with id %p, but it wasn't in lookup", canvas->get_port());
+    qd_log.error_f("Tried to delete canvas with id {}, but it wasn't in lookup", reinterpret_cast<const void*>(canvas->get_port()));
   }
 }
 
@@ -84,7 +84,7 @@ void deregister_canvas(const CGrafPtr port) {
   try {
     canvas_lookup.erase(port);
   } catch (std::out_of_range) {
-    qd_log.error("Tried to delete canvas with id %p, but it wasn't in lookup", port);
+    qd_log.error_f("Tried to delete canvas with id {}, but it wasn't in lookup", reinterpret_cast<const void*>(port));
   }
 }
 
@@ -133,7 +133,7 @@ void render_current_canvas(const SDL_FRect* rect) {
 PixPatHandle GetPixPat(uint16_t patID) {
   auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_ppat, patID);
   if (!data_handle) {
-    throw std::runtime_error(phosg::string_printf("Resource ppat:%hd was not found", patID));
+    throw std::runtime_error(std::format("Resource ppat:{} was not found", patID));
   }
   auto r = read_from_handle(data_handle);
   const auto& header = r.get<ResourceDASM::PixelPatternResourceHeader>();
@@ -200,7 +200,7 @@ PicHandle GetPicture(int16_t id) {
   auto p = ResourceDASM::ResourceFile::decode_PICT_only(*data_handle, GetHandleSize(data_handle));
 
   if (p.image.get_height() == 0 || p.image.get_width() == 0) {
-    throw std::runtime_error(phosg::string_printf("Failed to decode PICT %hd", id));
+    throw std::runtime_error(std::format("Failed to decode PICT {}", id));
   }
 
   // Normalize all image data to have an alpha channel, for convenience

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -30,15 +30,15 @@ public:
       return;
     }
     if (SDL_Init(SDL_INIT_AUDIO) < 0) {
-      sm_log.warning("Could not initialize audio subsystem: %s", SDL_GetError());
+      sm_log.warning_f("Could not initialize audio subsystem: {}", SDL_GetError());
       return;
     }
     this->device_id = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, NULL);
-    sm_log.info("Using device: %s ", SDL_GetAudioDeviceName(this->device_id));
+    sm_log.info_f("Using device: {}", SDL_GetAudioDeviceName(this->device_id));
     if (this->device_id == 0) {
-      sm_log.warning("Failed to open audio: %s", SDL_GetError());
+      sm_log.warning_f("Failed to open audio: {}", SDL_GetError());
     } else {
-      sm_log.info("Audio device paused: %d", SDL_AudioDevicePaused(this->device_id));
+      sm_log.info_f("Audio device paused: {}", SDL_AudioDevicePaused(this->device_id));
     }
   }
 
@@ -54,15 +54,15 @@ public:
     spec.freq = OUTPUT_SAMPLE_RATE;
     channel->sdlAudioStream = SDL_CreateAudioStream(&spec, &spec);
     if (channel->sdlAudioStream == NULL) {
-      sm_log.warning("Could not create SDL audio stream: %s", SDL_GetError());
+      sm_log.warning_f("Could not create SDL audio stream: {}", SDL_GetError());
       return nullptr;
     }
 
     SDL_BindAudioStream(this->device_id, channel->sdlAudioStream);
-    sm_log.info("Created output channel on audio stream device: %d", SDL_GetAudioStreamDevice(channel->sdlAudioStream));
+    sm_log.info_f("Created output channel on audio stream device: {}", SDL_GetAudioStreamDevice(channel->sdlAudioStream));
 
     if (SDL_SetAudioStreamFormat(channel->sdlAudioStream, &spec, NULL) < 0) {
-      sm_log.warning("Could not set audio stream format: %s", SDL_GetError());
+      sm_log.warning_f("Could not set audio stream format: {}", SDL_GetError());
     }
 
     this->all_channels.emplace(channel);
@@ -74,12 +74,12 @@ public:
     try {
       sound = this->sound_for_handle(data_handle);
     } catch (const std::exception& e) {
-      sm_log.warning("Can't find or decode sound: %s", e.what());
+      sm_log.warning_f("Can't find or decode sound: {}", e.what());
       return;
     }
 
     if (SDL_PutAudioStreamData(sdlAudioStream, sound->data.data(), sound->data.size()) < 0) {
-      sm_log.warning("Could not put audio stream data: %s", SDL_GetError());
+      sm_log.warning_f("Could not put audio stream data: {}", SDL_GetError());
     }
   }
 
@@ -176,7 +176,7 @@ OSErr SndNewChannel(SndChannelPtr* chan, uint16_t synth, int32_t init, void* use
     *chan = sm_chan.get();
     return noErr;
   } catch (const std::exception& e) {
-    sm_log.warning("Failed to create audio channel: %s", e.what());
+    sm_log.warning_f("Failed to create audio channel: {}", e.what());
     return badChannel;
   }
 }

--- a/src/StringConvert.hpp
+++ b/src/StringConvert.hpp
@@ -7,8 +7,8 @@
 template <size_t NumChars>
 std::string string_for_pstr(const unsigned char pstr[NumChars]) {
   if (pstr[0] >= NumChars) {
-    throw std::runtime_error(phosg::string_printf(
-        "Pascal string size field is too large; expected at most %zu bytes, received %hhu bytes",
+    throw std::runtime_error(std::format(
+        "Pascal string size field is too large; expected at most {} bytes, received {} bytes",
         NumChars, pstr[0]));
   }
   return std::string(reinterpret_cast<const char*>(pstr + 1), pstr[0]);
@@ -17,8 +17,8 @@ std::string string_for_pstr(const unsigned char pstr[NumChars]) {
 template <size_t NumChars>
 void pstr_for_string(unsigned char pstr[NumChars], const std::string& s) {
   if (s.size() >= NumChars) {
-    throw std::runtime_error(phosg::string_printf(
-        "data too long for Pascal string; expected at most %zu bytes, received %zu bytes",
+    throw std::runtime_error(std::format(
+        "data too long for Pascal string; expected at most {} bytes, received {} bytes",
         NumChars, s.size()));
   }
   pstr[0] = s.size();

--- a/src/tests/GraphicsTest.cpp
+++ b/src/tests/GraphicsTest.cpp
@@ -21,7 +21,7 @@ constexpr RGBColor white{255, 255, 255};
 
 int main() {
   if (!SDL_Init(SDL_INIT_VIDEO)) {
-    wm_log.error("Couldn't initialize video driver: %s\n", SDL_GetError());
+    wm_log.error_f("Couldn't initialize video driver: {}", SDL_GetError());
     return 1;
   }
 


### PR DESCRIPTION
This probably doesn't need careful review. The gist of it is that:
* Logger functions are now suffixed with `_f` and expect `std::format` syntax instead of `printf` syntax
* `phosg::string_printf` is gone; `std::format` is used instead
* `phosg::isdir` and similar functions are replaces with functions in `std::filesystem`