### PR TITLE
fix random rectangle bounds

### DIFF
--- a/src/realmz_orig/convert.h
+++ b/src/realmz_orig/convert.h
@@ -32,19 +32,10 @@ static inline void SLOWSWAP_BIG32(long* x) {
 #endif
 
 static inline void rintel2moto(Rect* r) {
-  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-   * NOTE(danapplegate): This function appears to date from the period where Apple computers
-   * transitioned from using the Motorola 68k series of chips to Intel. The former were big-endian, and
-   * the latter are little-endian. It's only used in two places when loading Rect objects from
-   * resource data, as the resource data appears to all be stored in big-endian order. (I'm not sure why
-   * the name is what it is, it seems like it should be converting _from_ moto _to_ intel?) However,
-   * ResourceDASM already handles the conversion for us, so we no longer need to do this.
-   */
-  // r->top = SWAP_BIG16(r->top);
-  // r->left = SWAP_BIG16(r->left);
-  // r->bottom = SWAP_BIG16(r->bottom);
-  // r->right = SWAP_BIG16(r->right);
-  /* *** END CHANGES *** */
+  r->top = SWAP_BIG16(r->top);
+  r->left = SWAP_BIG16(r->left);
+  r->bottom = SWAP_BIG16(r->bottom);
+  r->right = SWAP_BIG16(r->right);
 }
 
 static inline void CvtShortToPc(short* x) { SLOWSWAP_BIG16(x); }

--- a/src/realmz_orig/loadland-loadpixmap.c
+++ b/src/realmz_orig/loadland-loadpixmap.c
@@ -106,7 +106,13 @@ retry:
 
     SetGWorld(gthePixels, NIL);
     aire = ((**picture).picFrame);
-    rintel2moto(&aire);
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(fuzziqersoftware): GetPicture decodes the PICT internally and
+     * writes a header with picFrame in native byte order, so we don't need to
+     * byteswap the rect here using rintel2moto.
+     */
+    // rintel2moto(&aire);
+    /* *** END CHANGES *** */
     DrawPicture(picture, &aire);
     SetGWorld(savedPort, savedDevice); /********* reset drawing port to what it was before ****/
   } else {

--- a/src/realmz_orig/newland.c
+++ b/src/realmz_orig/newland.c
@@ -2346,7 +2346,13 @@ startover:
         picture = GetPicture(id);
         if (picture) {
           itemRect = (**picture).picFrame;
-          rintel2moto(&itemRect);
+          /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+           * NOTE(fuzziqersoftware): GetPicture decodes the PICT internally and
+           * writes a header with picFrame in native byte order, so we don't
+           * need to byteswap the rect here using rintel2moto.
+           */
+          // rintel2moto(&itemRect);
+          /* *** END CHANGES *** */
           OffsetRect(&itemRect, -itemRect.left, -itemRect.top);
           if ((itemRect.bottom < (320 + downshift)) || (itemRect.right < (320 + leftshift))) {
             itemRect.top = ((320 + downshift) - itemRect.bottom) / 2;


### PR DESCRIPTION
It turns out we can't disable rintel2moto entirely, because it also is used for byteswapping random rectangle bounds, and those *should* be byteswapped. This disables it at the relevant callsites instead.
