### PR TITLE
Fix crash when pressing conditions button twice

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -84,6 +84,18 @@ public:
   }
 
   void remove(int16_t menu_id) {
+    auto menu_handle = this->menu_id_to_handle.find(menu_id)->second;
+    auto menu = this->handle_to_menu.find(menu_handle)->second;
+
+    this->handle_to_menu.erase(menu_handle);
+    this->menu_id_to_handle.erase(menu_id);
+    for (auto m = this->res_id_to_menu.begin(); m != this->res_id_to_menu.end(); m++) {
+      if ((*m).second->menu_id == menu_id) {
+        this->res_id_to_menu.erase(m);
+        break;
+      }
+    }
+
     auto& menu_list = this->cur_menu_list->submenus;
     for (auto m = menu_list.begin(); m != menu_list.end(); m++) {
       if ((*m)->menu_id == menu_id) {


### PR DESCRIPTION
This resolves the crash noted in the minor issues burndown. The problem was that, when you press the Conditions button, it loads the popup menu, displays it, then diposes of it by first calling `DeleteMenu` and then `ReleaseResource` on the menu handle. However, the `DeleteMenu` function was not properly removing the loaded menu from all of our parallel lookups in MenuManager. So, when the Conditions button is clicked for a second time and MenuManager attempts to load the resource, it thinks that the menu is still fully loaded and returns it without loading the resource from ResourceManager. It's only later when it tries to release the handle that it discovers that the popup menu was not re-loaded, causing it to fail to find the menu by its resource handle and crashing.

This fixes the crash, but the conditions menu still doesn't display because it relies on the `PopUpMenuSelect` function, which we haven't implemented yet.