### PR TITLE
Install runtime dylibs in bundle, resolves #171

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,13 +382,16 @@ if(APPLE)
     # We dynamically link to the SDL* libraries (plus an asan lib that clang links against),
     # so we need to ensure that they get included in the bundle. MacOS supports rpaths, which
     # specify directly in the Mach-0 executable the directories in which runtime libraries may
-    # be found. I can't seem to figure out how to manipulate the rpath entries via CMake, which
-    # is complicated even further by the fact that the rpath should change between the build and
-    # install targets. However, the @executable_path symbolic directory always seems to be configured
-    # as an rpath, so if we install these runtime dylibs alongside the Realmz executable in 
-    # Contents/MacOS in the bundle, it should work.
+    # be found. By default, LIBRARY artifacts will be installed to Resources/lib in the bundle,
+    # so we set the RPATH below to this directory.
     install(IMPORTED_RUNTIME_ARTIFACTS Realmz RUNTIME_DEPENDENCY_SET runtimeDeps)
-    install(RUNTIME_DEPENDENCY_SET runtimeDeps LIBRARY DESTINATION "../MacOS")
+    install(RUNTIME_DEPENDENCY_SET runtimeDeps LIBRARY)
+
+    # Manually set the rpath to avoid CMake automatically adding hardcoded build machine paths
+    set_target_properties(Realmz PROPERTIES
+        INSTALL_RPATH "@executable_path/../Resources/lib"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
 elseif(WIN32)
     install(TARGETS Realmz DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${RESOURCE_FILES} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
@jpetrie reports in #171 (thank you!) that the MacOS distributable bundle .dmg has incorrectly hardcoded `rpaths`, which point to the host machine's build directory to find our SDL shared lib dependencies. This obviously doesn't work on target machines where SDL may not even be installed, let alone installed in my build directory.

Telling CMake to install these shared libs alongside the Realmz executable in the `Contents/MacOS` directory of the bundle (similar to including the .dlls alongside the executable on Windows) should work, because the special `@executable_path` is always configured as part of the rpath, and will point to wherever the Realmz executable will be found.

Unfortunately, my personal machine's build directory still appears among the `LC_RPATH` commands in the executable that we'll distribute, but that's merely an annoyance. Perhaps someone with more familiarity with CMake can suggest how we can remove it. Additional background information on [Apple's developer site](https://developer.apple.com/documentation/xcode/embedding-nonstandard-code-structures-in-a-bundle), and a [blog post I found helpful as well](https://blog.krzyzanowskim.com/2018/12/05/rpath-what/).

UPDATE: Thanks to advice from @jpetrie, I've managed to remove the hardcoded path to my build directory, and I was able to relocate the runtime libraries to `Resources/lib`.