### PR TITLE
Address pointer conversion warnings for strings.

### DIFF
--- a/src/FileManager.cpp
+++ b/src/FileManager.cpp
@@ -121,7 +121,7 @@ OSErr FSpDelete(const FSSpec* spec) {
 }
 
 OSErr FSMakeFSSpec(int16_t vRefNum, int32_t dirID, ConstStr255Param fileName, FSSpecPtr spec) {
-  memcpy(spec->name, fileName, fileName[0] + 1);
+  memcpy(spec->name, fileName, static_cast<uint8_t>(fileName[0]) + 1);
   spec->vRefNum = vRefNum;
   spec->parID = dirID;
   return 0;

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -569,7 +569,7 @@ Handle Get1Resource(ResType type, int16_t id) {
     if (type == 'PRFN' && id == 128 /* PREF_RES_ID */) {
       SetHandleSize(res->data_handle, sizeof(PrefRecord));
       auto pref_handle = (PrefHandle)res->data_handle;
-      int name_str_size = (int)(*pref_handle)->name_str[0];
+      int name_str_size = static_cast<uint8_t>((*pref_handle)->name_str[0]);
       auto end_of_name_str = (char*)*pref_handle + offsetof(PrefRecord, name_str) + 1 + name_str_size;
       memmove((char*)*pref_handle + offsetof(PrefRecord, autonote), end_of_name_str, 18);
     }

--- a/src/StringConvert.hpp
+++ b/src/StringConvert.hpp
@@ -5,17 +5,18 @@
 #include <string>
 
 template <size_t NumChars>
-std::string string_for_pstr(const unsigned char pstr[NumChars]) {
-  if (pstr[0] >= NumChars) {
+std::string string_for_pstr(const char pstr[NumChars]) {
+  unsigned char size = static_cast<unsigned char>(pstr[0]);
+  if (size >= NumChars) {
     throw std::runtime_error(std::format(
         "Pascal string size field is too large; expected at most {} bytes, received {} bytes",
-        NumChars, pstr[0]));
+        NumChars, size));
   }
-  return std::string(reinterpret_cast<const char*>(pstr + 1), pstr[0]);
+  return std::string(reinterpret_cast<const char*>(pstr + 1), size);
 }
 
 template <size_t NumChars>
-void pstr_for_string(unsigned char pstr[NumChars], const std::string& s) {
+void pstr_for_string(char pstr[NumChars], const std::string& s) {
   if (s.size() >= NumChars) {
     throw std::runtime_error(std::format(
         "data too long for Pascal string; expected at most {} bytes, received {} bytes",

--- a/src/Types.h
+++ b/src/Types.h
@@ -38,12 +38,12 @@ typedef unsigned char Boolean;
 #define noErr 0
 #define resProblem -204
 
-typedef unsigned char Str255[256];
-typedef unsigned char Str63[64];
-typedef unsigned char* StringPtr;
+typedef char Str255[256];
+typedef char Str63[64];
+typedef char* StringPtr;
 typedef StringPtr* StringHandle;
-typedef const unsigned char* ConstStr255Param;
-typedef const unsigned char* ConstStr63Param;
+typedef const char* ConstStr255Param;
+typedef const char* ConstStr63Param;
 
 // See also the C++ versions of these in resource_file/ResourceFormats.hh
 typedef struct {

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1484,7 +1484,7 @@ void SetDialogItemText(DialogItemHandle item_handle, ConstStr255Param text) {
 }
 
 int16_t StringWidth(ConstStr255Param s) {
-  return s[0];
+  return static_cast<uint8_t>(s[0]);
 }
 
 Boolean IsDialogEvent(const EventRecord* ev) {
@@ -1678,7 +1678,7 @@ void StringToNum(ConstStr255Param str, int32_t* num) {
   //   ASCII code for a space is $20.
   // We implement the same behavior here.
   *num = 0;
-  if (str[0] > 0) {
+  if (static_cast<uint8_t>(str[0]) > 0) {
     bool negative = (str[1] == '-');
     size_t offset = negative ? 1 : 0;
     for (size_t z = 0; z < static_cast<uint8_t>(str[0]); z++) {

--- a/src/realmz_orig/editspellnames.c
+++ b/src/realmz_orig/editspellnames.c
@@ -43,13 +43,19 @@ OSErr SetIndString(StringPtr theStr, short resID, short strIndex) {
   offset = sizeof(short); /* get a pointer to the string to replace */
   resStr = (char*)*theRes + sizeof(short);
 
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(jpetrie): The original implementation of the remainder of this function used "str[0]" indexing to get the
+   * size of a variety of Pascal strings. Since string types are signed now, each of those lines have been updated to
+   * cast to uint8_t to ensure that longer strings don't result in bugs because their length byte was interpreted as a
+   * negative value.
+   */
   for (ourString = 1; ourString < strIndex; ourString++) {
-    offset += 1 + resStr[0];
-    resStr += 1 + resStr[0];
+    offset += 1 + (uint8_t)resStr[0];
+    resStr += 1 + (uint8_t)resStr[0];
   }
 
   oldSize = GetHandleSize(theRes); /* grow/shrink resource handle to make room for new string */
-  newSize = oldSize - resStr[0] + theStr[0];
+  newSize = oldSize - (uint8_t)resStr[0] + (uint8_t)theStr[0];
   HUnlock(theRes);
   SetHandleSize(theRes, newSize);
 
@@ -62,10 +68,10 @@ OSErr SetIndString(StringPtr theStr, short resID, short strIndex) {
   resStr = *theRes + offset;
 
   /* move old data forward/backward to make room */
-  BlockMove(resStr + resStr[0] + 1, resStr + theStr[0] + 1, oldSize - offset - resStr[0] - 1);
+  BlockMove(resStr + (uint8_t)resStr[0] + 1, resStr + (uint8_t)theStr[0] + 1, oldSize - offset - (uint8_t)resStr[0] - 1);
 
   /* move new data in */
-  BlockMove(theStr, resStr, theStr[0] + 1);
+  BlockMove(theStr, resStr, (uint8_t)theStr[0] + 1);
 
   /* write resource out */
 

--- a/src/realmz_orig/files.c
+++ b/src/realmz_orig/files.c
@@ -23,9 +23,15 @@ char* dialog_open_file(const char** types, const char* prompt) {
 
   type_count = i;
 
-  SFGetFile(where, (const unsigned char*)p_prompt, NULL, -1, sf_types, NULL, &sf_reply);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(jpetrie): In the original implementation, p_prompt was cast to "const unsigned char*" - this isn't neccessary
+   * any longer since SFGetFile() takes a signed char string. The length byte of fName has also been explicitly cast to
+   * an unsigned value to ensure it is handled properly.
+   */
+  SFGetFile(where, p_prompt, NULL, -1, sf_types, NULL, &sf_reply);
   if (sf_reply.good) {
-    filename = (char*)malloc(sf_reply.fName[0] + 1);
+
+    filename = (char*)malloc((uint8_t)sf_reply.fName[0] + 1);
     // GetFInfo(sf_reply.fName, sf_reply.
     P2CStr(sf_reply.fName);
     strcpy(filename, (const char*)sf_reply.fName);
@@ -45,9 +51,14 @@ char* dialog_save_file(const char* prompt, const char* default_name) {
   strncpy(p_default, default_name, sizeof(p_default));
   C2PStr(p_default);
 
-  SFPutFile(where, (unsigned char*)p_prompt, (unsigned char*)p_default, NULL, &sf_reply);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(jpetrie): In the original implementation, p_prompt and p_default were cast to unsigned types - this isn't
+   * neccessary any longer since SFPutFile() takes signed char strings. The length byte of fName has also been
+   * explicitly cast to an unsigned value to ensure it is handled properly.
+   */
+  SFPutFile(where, p_prompt, p_default, NULL, &sf_reply);
   if (sf_reply.good) {
-    filename = (char*)malloc(sf_reply.fName[0] + 1);
+    filename = (char*)malloc((uint8_t)sf_reply.fName[0] + 1);
     // GetFInfo(sf_reply.fName, sf_reply.
     P2CStr(sf_reply.fName);
     strcpy(filename, (char*)sf_reply.fName);

--- a/src/realmz_orig/textbox-time.c
+++ b/src/realmz_orig/textbox-time.c
@@ -53,14 +53,17 @@ void textbox(short class, short index, short click, short different, Rect newrec
    * The original code takes the raw result from GetIndString and puts it into
    * the TextEdit object, then calls TESetSelect and TEDelete to delete the
    * Pascal string length field off of the beginning. We handle the Pascal
-   * string length field properly instead. */
+   * string length field properly instead.
+   *
+   * NOTE(jpetrie): This change also now ensures the Pascal string length byte is cast to an unsigned type.
+   */
   // TESetText(myString, 255, messagetext);
   // MyrDump("textbox :[%s]\n", myString);
   // TESetSelect(0, 1, messagetext);
   // #ifndef PC // Myriad
   //   TEDelete(messagetext);
   // #endif
-  TESetText(&myString[1], myString[0], messagetext);
+  TESetText(&myString[1], (uint8_t)myString[0], messagetext);
   /* *** END CHANGES *** */
   EraseRect(&userect);
   if (!different)


### PR DESCRIPTION
This PR proposes changes that address one of the biggest sources of warnings in the code, pointer signedness conversions for strings. This cuts the warning count by half.

The main change here is to switch the various string types in `Types.h` to `char` from `unsigned char`. Because the majority of string usage in the code is actual C strings (which are passed to C standard library functions), this silences almost all of the warnings. For the cases where actual Pascal strings appear (and the length byte is tested), I've made sure to cast the byte to an unsigned value to ensure that any math done with it does not treat it as a signed value. The only place I found in my audit that I left alone was the registration code handling section, since it isn't used.

I opted for this approach because it would be fairly easy to revert locally (just add `unsigned` back to `Types.h` - the various casts can be left alone since they'll become no-ops) if A/B testing is needed, and because the other options that I explored ultimately seemed worse.

For reference, the other options I considered were:

 - Adding macros for the various C string functions that are used to redirect them to functions taking `unsigned char` strings. This isn't good practice, and in fact fails because those functions are _already_ macros in the standard library implementation (to handle redirects to secure versions).
 - Replacing every warning site with a new actual function that addresses the conversion warning. This quickly becomes really intrusive and verbose since most of these call sites are in the original Realmz code, and doesn't fundamentally treat the problem any differently than just redefining the string type. It would also be harder to temporarily undo locally.
 - Clever C++ template tricks to catch C versus Pascal string mismatches at compile time. This of course fails immediately because most of the code is C. Oops.
 - Disabling the warning. This is the least invasive option, but I think it's the worst: for strings, whether or not the characters are signed or not doesn't really matter except for that length byte in the front. But the actual warning applies to pointers of all integer types, and I thought removing that safety net for pointers to integers that are more likely to be used for actual math would be a bad idea.

I tested this by playing through Bywater for an hour or so. Not exhaustive, but I found a few mistakes right of the bat and once I fixed those I didn't see any other issues.
