### PR TITLE
Copy runtime files to the build directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,12 @@ target_link_libraries(Realmz
 target_compile_options(Realmz PRIVATE -fsanitize=address)
 target_link_options(Realmz PRIVATE -fsanitize=address)
 
+# Ensure the files the bare Realmz executable needs exist in the build directory.
+add_custom_command(TARGET Realmz POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/resources" "$<TARGET_FILE_DIR:Realmz>"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/base/Realmz" "$<TARGET_FILE_DIR:Realmz>"
+)
+
 set(TEST_EXECUTABLES "GraphicsTest")
 foreach(TEST_EXECUTABLE ${TEST_EXECUTABLES})
     add_executable(${TEST_EXECUTABLE} MACOSX_BUNDLE


### PR DESCRIPTION
As an alternative to generating the Realmz bundle during the regular build step (as in PR #172), this PR adds a post-build command to the Realmz target to ensure the required runtime data exists next to the built executable.

This ensures that local (non-package target) builds can be run under a debugger without having to manually move files around.

Only one of these two PRs should be merged, naturally. I think #172 is the better long-term approach since it means local builds look more like shipping builds, but either of them will result in a better out-of-the-box experience for new contributors.

This PR would also close #168.