### PR TITLE
Throttle key repeats to avoid sluggish gameplay.

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -9,11 +9,6 @@
 #include "Types.hpp"
 #include "WindowManager.hpp"
 
-// Defined in main.c of the original Realmz code, this value is the base scalar for the game speed. It is used in this
-// file to prevent repeated key down events from clogging the event queue faster than the game will read them; see the
-// code in EventManager::enqueue_sdl_event().
-extern short oldspeed;
-
 static phosg::PrefixedLogger em_log("[EventManager] ", DEFAULT_LOG_LEVEL);
 
 static constexpr uint16_t EVMOD_RIGHT_CONTROL_KEY_DOWN = 0x8000;
@@ -445,23 +440,14 @@ protected:
           if (e.type == SDL_EVENT_KEY_DOWN) {
             // Key down repeats can come in faster than Realmz will process them, depending on the game speed settings.
             // When key events get backlogged in that fashion, the game appears sluggish until it clears the queue. To
-            // prevent that, key repeats are deduplicated so that no key repeat enters the queue faster than the game
-            // speed. The queue is scanned backwards since events are inserted at the back.
+            // prevent that, key repeats are deduplicated so that no key repeat enters the queue until the previous one
+            // has been processed. The queue is scanned backwards since events are inserted at the back.
             auto cursor = event_queue.rbegin();
             while (cursor != event_queue.rend()) {
               EventRecord& existing = *cursor;
               if (existing.what == keyDown && existing.message == message) {
-                // Determine how long it's been since the most recent key down event for this same key.
-                uint32_t duration = TickCount() - existing.when;
-
-                // Note that calculation used for the actual checkdelay() function in Realmz is "2 * oldspeed * scale"
-                // where scale is the parameter to checkdelay(), but Realmz never calls it with a value other than 1.
-                uint32_t threshold = 2 * oldspeed;
-                if (duration < threshold) {
-                  em_log.info_f("Deduplicating key down for key=0x{:X}; {} ticks since previous event (threshold is {}).", static_cast<size_t>(e.key.key), duration, threshold);
-                  enqueue = false;
-                  break;
-                }
+                em_log.info_f("Deduplicating key down for key=0x{:X}.", static_cast<size_t>(e.key.key));
+                enqueue = false;
               }
 
               ++cursor;


### PR DESCRIPTION
This change prevents key down events from being enqueued if they are for a key that has an existing keydown in the queue that occurred sooner than a given threshold. The threshold is set to the amount of time Realmz will wait, via `checkdelay()`, before advancing the game state. Since Realmz uses a busy-wait loop to implement that delay, events aren't processed and can build up in the queue, resulting in a lack of player control as Realmz drains the key repeats.

This would fix #199.