### PR TITLE
save storeditems flag in save file

### DIFF
--- a/src/realmz_orig/loadsavedgame.c
+++ b/src/realmz_orig/loadsavedgame.c
@@ -392,7 +392,11 @@ short load(void) {
   fread(&spellcasting, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
   fread(&spellcharging, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
   fread(&monstercasting, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
-  fread(&spareboolean, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
+  // NOTE(fuzziqersoftware): This was previously `spareboolean`, which was unused and had the value 0 in all builds. We
+  // repurpose this field to store `storeditems`, which isn't the same size but is also semantically boolean.
+  Boolean storeditems_value = FALSE;
+  fread(&storeditems_value, sizeof(Boolean), 1, fp);
+  storeditems = storeditems_value;
 
   fclose(fp);
 

--- a/src/realmz_orig/main.c
+++ b/src/realmz_orig/main.c
@@ -306,7 +306,7 @@ char xydisplayflag = 0;
 char blanksavegamevariables[14]; //**** only 18 are left,  used two for templecost move.
 
 short cancamp, storeditems;
-Boolean spellcasting, spellcharging, monstercasting, spareboolean;
+Boolean spellcasting, spellcharging, monstercasting;
 
 short storageitems[180] = {0};
 int32_t myrmagic_storageitems = MYRMAGIC;

--- a/src/realmz_orig/save-direction-order.c
+++ b/src/realmz_orig/save-direction-order.c
@@ -465,7 +465,10 @@ void save(short mode) {
   fwrite(&spellcasting, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
   fwrite(&spellcharging, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
   fwrite(&monstercasting, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
-  fwrite(&spareboolean, sizeof(Boolean), 1, fp); //*** fantasoft v7.1b  Added as was missing in previous version.
+  // NOTE(fuzziqersoftware): This was previously `spareboolean`, which was unused and had the value 0 in all builds. We
+  // repurpose this field to store `storeditems`, which isn't the same size but is also semantically boolean.
+  Boolean storeditems_value = storeditems;
+  fwrite(&storeditems_value, sizeof(Boolean), 1, fp);
 
   fclose(fp);
 

--- a/src/realmz_orig/variables.h
+++ b/src/realmz_orig/variables.h
@@ -178,7 +178,7 @@ extern ControlHandle departshop, poolshop, shareshop, castspellsbut, viewspellsb
 extern ControlHandle torch, showitems, search, attacks, condition, monsterbut, showitembut, showconditionbut;
 extern ControlHandle autoone[6];
 extern short cancamp, storeditems;
-extern Boolean spellcasting, spellcharging, monstercasting, spareboolean;
+extern Boolean spellcasting, spellcharging, monstercasting;
 extern char savedpostion[2], savedlandtype, savedlandlevel;
 extern short sparesavedgamevariables[4];
 extern DialogPtr gCurrent, gGeneration, dummy, background;


### PR DESCRIPTION
This fixes the stash/retrieve party equipment opcode. It seems this opcode never worked properly if the game was restarted (and the saved game loaded) while the party's equipment was stashed - their stashed equipment would be lost forever!