### PR TITLE
fix fumble command edge case in battle

### DIFF
--- a/src/realmz_orig/newland.c
+++ b/src/realmz_orig/newland.c
@@ -386,7 +386,7 @@ startover:
             monster[monsterup].weapon = 0;
             sound(-10121);
             sound(-655);
-            combatupdate2(monsterup);
+            combatupdate2(monsterup + 10);
             showresults(monsterup, -46, monsterup);
           } else
             return (0);


### PR DESCRIPTION
If a monster or NPC kills another monster, and the killed monster has a macro which causes a weapon fumble, the macro's opcode handler will try to update the wrong entity. Battle entities are 0-5 for party characters and 10+ for monsters; in rare cases, the absence of this `+ 10` can cause the game to try to update players in the 6-9 range, which leads to out-of-bounds memory accesses.