### PR TITLE
Fix Windows Cross-Compilation Build

### DIFF
--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -195,7 +195,7 @@ int WinCreatePopupMenu(SDL_Window* sdl_window, std::shared_ptr<WinMenu> menu) {
   for (const auto& item : menu->items) {
     i++;
     auto name = item.name.c_str();
-    AppendMenu(popupMenu, (item->enabled ? MF_ENABLED : 0) | MF_STRING, i, name);
+    AppendMenu(popupMenu, (item.enabled ? MF_ENABLED : 0) | MF_STRING, i, name);
   }
 
   // TrackPopupMenu displays the menu in screen coordinates, not window coordinates. Rather


### PR DESCRIPTION
I'm getting the following when attempting to build for the Windows target:

```
src/windows/WinMenuController.cpp:198:32: error: member reference type 'WinMenu::Item const' is not a pointer; did you mean
      to use '.'?
  198 |     AppendMenu(popupMenu, (item->enabled ? MF_ENABLED : 0) | MF_STRING, i, name);
      |                            ~~~~^~
      |                                .
1 error generated.
```

I believe this was introduced [here](https://github.com/Realmz-Castle/realmz/commit/c4e989f9e99f8b7ef3debe6c202401bb99f0c316#diff-589f981c4c89d2402889f1322f5b8e6dc0d0f973c89bcfe044c033153ae08620L198-L205). This PR fixes the member access.