### PR TITLE
fix hang in Name modal on Generate New Character

### DIFF
--- a/src/realmz_orig/name.c
+++ b/src/realmz_orig/name.c
@@ -116,6 +116,9 @@ over:
             }
           }
           */
+          gStop = 1;
+          sound(6001);
+          goto out;
         }
       } else {
         sound(6000);


### PR DESCRIPTION
Issue: launch current build, menu bar > Character > Generate New Character, type a name and hit OK. Result: modal hangs.

Cause: commit 6911d5c commented out modal dismissal, sound call, goto while removing Data CD

Fix: this PR restores the three lines required.

Tested fix in new build, issue resolved.