### PR TITLE
stop character hiding on empty slot click

### DIFF
--- a/src/realmz_orig/partyselect.c
+++ b/src/realmz_orig/partyselect.c
@@ -395,15 +395,24 @@ shortupdate:
       strncat(filename, myString, 30);
 
       if ((fp = MyrFopen(filename, "rb")) == NULL) {
+        /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+         * NOTE(chromancer): Bug in original code hides selected character
+         * when fopen fails, which vanishes the selected on an empty-slot
+         * click. Fix: guard on the clicked slot having had a name. warn()
+         * overwrites global myString, so capture check before warn().
+         */
+        short clicked_empty = !strlen(myString);
         SetPortDialogPort(party);
         ForeColor(blackColor);
         BackColor(whiteColor);
         warn(38);
         warn(143);
-        GetDialogItem(party, filepick, &itemType, &itemHandle, &itemRect);
-        GetDialogItemText(itemHandle, myString);
-        PtoCstr(myString);
-        minus((Ptr)myString, 1);
+        if (!clicked_empty) {
+          GetDialogItem(party, filepick, &itemType, &itemHandle, &itemRect);
+          GetDialogItemText(itemHandle, myString);
+          PtoCstr(myString);
+          minus((Ptr)myString, 1);
+        }
         goto bigupdate;
       }
 


### PR DESCRIPTION
issue: Clicking empty slot while any character is selected triggers double popups and hides the selected character from the list (until quit/relaunch in current build). This is original behavior.

Empty slot > empty text > fopen fails > calls minus(filepick_text, 1), which hides wrong character.

Fix: guard minus() call on clicked slot having had a name. 

note warn() stomps myString, so stashed empty-check in a local.

I left the annoying popups for nostalgia purposes. If you want to lose that behavior also it can be done but it isn't original.

This is other half of fix for #161 I think. Can't reproduce on Windows. This plays clean on my build.