### PR TITLE
Change TickCount() to wall clock rather than clock()

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -518,7 +518,7 @@ protected:
 EventManager em;
 
 uint32_t TickCount(void) {
-  return (clock() * 60) / CLOCKS_PER_SEC;
+  return (SDL_GetTicks() * 60) / SDL_MS_PER_SECOND;
 }
 
 uint32_t GetDblTime(void) {


### PR DESCRIPTION
issue: animations such as the volcano flame/sound on title screen run at weird slow speeds, animation pacing is off generally, delays are drifting also.

cause: TickCount() currently uses clock(), CPU time. Classic Mac TickCount() is wall clock.

fix: swap to SDL_GetTicks.

downstream effects: Since orig classic Mac Realmz was paced on wall clock, this ought to significantly decrease pacing, animation, and event discrepancies. Can confirm immediate rejuvenation of the volcano. I suspect big effect on #199 and I will experiment with effects on #201. Also has benefit of making double click time work as intended. Game speed prefs should be more predictable.

tested on Mac build. No reason it shouldn't work on Windows.