### PR TITLE
icons restored to Mac menus and dropdowns

### DIFF
--- a/src/MenuManager-C-Interface.h
+++ b/src/MenuManager-C-Interface.h
@@ -31,6 +31,7 @@ int32_t PopUpMenuSelect(MenuHandle menu, int16_t top, int16_t left, int16_t popU
 void AppendMenu(MenuHandle menu, ConstStr255Param data);
 int16_t CountMItems(MenuHandle theMenu);
 int32_t MenuKey(int16_t ch);
+void MM_SetItemIcon(MenuHandle theMenu, int16_t item, int16_t iconID);
 
 #ifdef __cplusplus
 }

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -293,3 +293,13 @@ int16_t CountMItems(MenuHandle theMenu) {
 int32_t MenuKey(int16_t ch) {
   return 0;
 }
+
+void MM_SetItemIcon(MenuHandle theMenu, int16_t item, int16_t iconID) {
+  auto menu = mm.get_menu(theMenu);
+  if (item < 1 || item > static_cast<int16_t>(menu->items.size())) {
+    mm_log.warning_f("Attempted to set icon of MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
+    return;
+  }
+  menu->items.at(item - 1).icon_id = iconID;
+  mm.sync();
+}

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -301,5 +301,4 @@ void MM_SetItemIcon(MenuHandle theMenu, int16_t item, int16_t iconID) {
     return;
   }
   menu->items.at(item - 1).icon_id = iconID;
-  mm.sync();
 }

--- a/src/MenuManager.hpp
+++ b/src/MenuManager.hpp
@@ -6,7 +6,7 @@
 struct Menu {
   struct Item {
     std::string name;
-    uint8_t icon_number = 0;
+    int16_t icon_id = 0; // Absolute cicn resource id
     char key_equivalent = 0;
     char mark_character = 0; // In MacRoman; use decode_mac_roman if needed
     uint8_t style_flags = 0; // See TextStyleFlag
@@ -18,7 +18,7 @@ struct Menu {
 
     Item(ResourceDASM::ResourceFile::DecodedMenu::Item& item)
         : name{item.name},
-          icon_number{item.icon_number},
+          icon_id{static_cast<int16_t>(item.icon_number ? 256 + item.icon_number : 0)}, // icon number to resource id (0 for none)
           key_equivalent{item.key_equivalent},
           mark_character{item.mark_character},
           style_flags{item.style_flags},

--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -825,6 +825,15 @@ CIconHandle GetCIcon(uint16_t iconID) {
   return h;
 }
 
+phosg::ImageRGBA8888N DecodeCIconImage(int16_t iconID) {
+  auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_cicn, iconID);
+  if (data_handle == NULL) {
+    throw std::runtime_error(std::format("cicn resource {} not found", iconID));
+  }
+  auto decoded = ResourceDASM::ResourceFile::decode_cicn(*data_handle, GetHandleSize(data_handle));
+  return std::move(decoded.image);
+}
+
 OSErr DisposeCIcon(CIconHandle icon) {
   if ((*icon)->iconData) {
     DisposeHandle((*icon)->iconData);

--- a/src/QuickDraw.hpp
+++ b/src/QuickDraw.hpp
@@ -111,3 +111,6 @@ SDL_Color GetBackColorSDL();
 SDL_Color GetForeColorSDL();
 
 CCGrafPort& current_port();
+
+// Decodes cicn resource into a phosg-native RGBA
+phosg::ImageRGBA8888N DecodeCIconImage(int16_t iconID);

--- a/src/RealmzCocoa.c
+++ b/src/RealmzCocoa.c
@@ -80,6 +80,7 @@ void HiliteMenu(int16_t menuID) {
 }
 
 void SetItemIcon(MenuHandle theMenu, int16_t item, int16_t iconIndex) {
+  MM_SetItemIcon(theMenu, item, iconIndex);
 }
 
 void SelectDialogItemText(DialogPtr theDialog, int16_t itemNo, int16_t strtSel, int16_t endSel) {

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -4,10 +4,62 @@
 #include <cstddef>
 #include <cstdint>
 #include <objc/NSObject.h>
-#include <resource_file/ResourceFile.hh>
+#include <phosg/Image.hh>
 
 NSMenu* MCCreateMenu(const MenuList& menuList);
 NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<std::shared_ptr<Menu>> submenus);
+
+// We have to forward declare because of PixMap collision w/QuickDraw
+phosg::ImageRGBA8888N DecodeCIconImage(int16_t iconID);
+
+// Wraps a decoded cicn as an NSImage, NN scale 2x, byteswap BGRA->RGBA.
+static constexpr NSInteger kMenuIconUpscale = 2;
+
+static NSImage* MCImageForCicn(int16_t cicnID) {
+  if (cicnID == 0) {
+    return nil;
+  }
+  try {
+    auto decoded = DecodeCIconImage(cicnID);
+    NSInteger srcW = decoded.get_width();
+    NSInteger srcH = decoded.get_height();
+    if (srcW <= 0 || srcH <= 0) {
+      return nil;
+    }
+    NSInteger dstW = srcW * kMenuIconUpscale;
+    NSInteger dstH = srcH * kMenuIconUpscale;
+    NSBitmapImageRep* rep = [[NSBitmapImageRep alloc]
+        initWithBitmapDataPlanes:NULL
+                      pixelsWide:dstW
+                      pixelsHigh:dstH
+                   bitsPerSample:8
+                 samplesPerPixel:4
+                        hasAlpha:YES
+                        isPlanar:NO
+                  colorSpaceName:NSDeviceRGBColorSpace
+                    bitmapFormat:0
+                     bytesPerRow:dstW * 4
+                    bitsPerPixel:32];
+    if (rep == nil) {
+      return nil;
+    }
+    const uint32_t* src = decoded.get_data();
+    uint32_t* dst = reinterpret_cast<uint32_t*>([rep bitmapData]);
+    for (NSInteger y = 0; y < dstH; y++) {
+      const uint32_t* srcRow = src + (y / kMenuIconUpscale) * srcW;
+      uint32_t* dstRow = dst + y * dstW;
+      for (NSInteger x = 0; x < dstW; x++) {
+        dstRow[x] = __builtin_bswap32(srcRow[x / kMenuIconUpscale]);
+      }
+    }
+    [rep setSize:NSMakeSize(srcW, srcH)];
+    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(srcW, srcH)];
+    [image addRepresentation:rep];
+    return image;
+  } catch (const std::exception&) {
+    return nil;
+  }
+}
 
 @interface MCMenuItemIdentifier : NSObject
 
@@ -91,6 +143,10 @@ NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<st
         if (subMenuItemRes.checked) {
           subMenuItem.state = NSControlStateValueOn;
         }
+        NSImage* icon = MCImageForCicn(subMenuItemRes.icon_id);
+        if (icon != nil) {
+          [subMenuItem setImage:icon];
+        }
 
         // Submenu ids are specified by the itemMark field if the itemCmd field has
         // the value 0x1B
@@ -158,6 +214,10 @@ NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<st
     id menuIdentifier = [[MCMenuItemIdentifier alloc] initWithRawIds:menu->menu_id itemId:itemId];
     [menuItem setRepresentedObject:menuIdentifier];
     menuItem.enabled = item.enabled;
+    NSImage* icon = MCImageForCicn(item.icon_id);
+    if (icon != nil) {
+      [menuItem setImage:icon];
+    }
     [_contextualMenu addItem:menuItem];
   }
 

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -49,7 +49,11 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
       const uint32_t* srcRow = src + (y / kMenuIconUpscale) * srcW;
       uint32_t* dstRow = dst + y * dstW;
       for (NSInteger x = 0; x < dstW; x++) {
-        dstRow[x] = __builtin_bswap32(srcRow[x / kMenuIconUpscale]);
+        uint32_t pixel = srcRow[x / kMenuIconUpscale];
+        if constexpr (!phosg::IS_BIG_ENDIAN) {
+          pixel = __builtin_bswap32(pixel);
+        }
+        dstRow[x] = pixel;
       }
     }
     [rep setSize:NSMakeSize(srcW, srcH)];

--- a/src/windows/MenuController.cpp
+++ b/src/windows/MenuController.cpp
@@ -7,7 +7,7 @@
 WinMenu::Item win_menu_item_from_menu_item(const Menu::Item& item) {
   return WinMenu::Item{
       .name = item.name,
-      .icon_number = item.icon_number,
+      .icon_id = item.icon_id,
       .key_equivalent = item.key_equivalent,
       .mark_character = item.mark_character,
       .style_flags = item.style_flags,

--- a/src/windows/WinMenuController.hpp
+++ b/src/windows/WinMenuController.hpp
@@ -7,7 +7,7 @@
 struct WinMenu {
   struct Item {
     std::string name;
-    uint8_t icon_number;
+    int16_t icon_id;
     char key_equivalent;
     char mark_character; // In MacRoman; use decode_mac_roman if needed
     uint8_t style_flags; // See TextStyleFlag


### PR DESCRIPTION
This PR contains Mac-side support for menu and dropdown items with cicns (#156)

- Store absolute cicn resource ids on Menu::Item, converting at parse
- Add DecodeCIconImage to get RGBA
- NSImage with 2x so they're not tiny, attach to Cocoa controller
- SetItemIcon now implemented

Despite touched files I didn't do anything Windows-side, just rename the field to be more inline with how it comes out now.