### PR TITLE
add item marks & remove sync-on-change hangs

### DIFF
--- a/src/MenuManager-C-Interface.h
+++ b/src/MenuManager-C-Interface.h
@@ -27,6 +27,8 @@ int32_t MenuSelect(Point startPt);
 void DisableItem(MenuHandle theMenu, uint16_t item);
 void EnableItem(MenuHandle theMenu, uint16_t item);
 void CheckItem(MenuHandle theMenu, uint16_t item, Boolean checked);
+void SetItemMark(MenuHandle theMenu, int16_t item, int16_t markChar);
+void GetItemMark(MenuHandle theMenu, int16_t item, int16_t* markChar);
 int32_t PopUpMenuSelect(MenuHandle menu, int16_t top, int16_t left, int16_t popUpItem);
 void AppendMenu(MenuHandle menu, ConstStr255Param data);
 int16_t CountMItems(MenuHandle theMenu);

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -205,7 +205,6 @@ void SetMenuItemText(MenuHandle theMenu, uint16_t item, ConstStr255Param itemStr
     return;
   }
   menu->items.at(item - 1).name = string_for_pstr<256>(itemString);
-  mm.sync();
 }
 
 int32_t MenuSelect(Point startPt) {
@@ -224,7 +223,6 @@ void DisableItem(MenuHandle theMenu, uint16_t item) {
   } else {
     mm_log.warning_f("Attempted to disable MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
   }
-  mm.sync();
 }
 
 void EnableItem(MenuHandle theMenu, uint16_t item) {
@@ -236,7 +234,6 @@ void EnableItem(MenuHandle theMenu, uint16_t item) {
   } else {
     mm_log.warning_f("Attempted to enable MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
   }
-  mm.sync();
 }
 
 void CheckItem(MenuHandle theMenu, uint16_t item, Boolean checked) {
@@ -246,7 +243,24 @@ void CheckItem(MenuHandle theMenu, uint16_t item, Boolean checked) {
   } else {
     menu->items.at(item - 1).checked = checked;
   }
-  mm.sync();
+}
+
+void SetItemMark(MenuHandle theMenu, int16_t item, int16_t markChar) {
+  auto menu = mm.get_menu(theMenu);
+  if (item < 1 || item > static_cast<int16_t>(menu->items.size())) {
+    mm_log.warning_f("Attempted to set mark of MENU:{} item {}, but it doesn't exist", menu->menu_id, item);
+    return;
+  }
+  menu->items.at(item - 1).mark_character = static_cast<char>(markChar);
+}
+
+void GetItemMark(MenuHandle theMenu, int16_t item, int16_t* markChar) {
+  auto menu = mm.get_menu(theMenu);
+  if (item < 1 || item > static_cast<int16_t>(menu->items.size())) {
+    *markChar = 0;
+    return;
+  }
+  *markChar = static_cast<int16_t>(menu->items.at(item - 1).mark_character);
 }
 
 void AppendMenu(MenuHandle menu, ConstStr255Param data) {

--- a/src/RealmzCocoa.c
+++ b/src/RealmzCocoa.c
@@ -105,10 +105,6 @@ int16_t OpenDeskAcc(ConstStr255Param deskAccName) {
   return 0;
 }
 
-void SetItemMark(MenuHandle theMenu, int16_t item, int16_t markChar) {
-  // TODO
-}
-
 void EndUpdate(WindowPtr theWindow) {
 }
 
@@ -142,9 +138,6 @@ void SysBeep(uint16_t duration) {
 }
 
 void UnlockPixels(PixMapHandle pm) {
-}
-
-void GetItemMark(MenuHandle theMenu, int16_t item, int16_t* markChar) {
 }
 
 void LMSetMBarHeight(int16_t h) {

--- a/src/RealmzCocoa.h
+++ b/src/RealmzCocoa.h
@@ -183,8 +183,6 @@ int16_t DIBadMount(Point where, int32_t evtMessage);
 #define GetWindowPort(x) (x)
 #define BitAnd(x, y) ((x) & (y))
 int16_t OpenDeskAcc(ConstStr255Param deskAccName);
-void SetItemMark(MenuHandle theMenu, int16_t item, int16_t markChar);
-void GetItemMark(MenuHandle theMenu, int16_t item, int16_t* markChar);
 #define GetMBarHeight() 20
 void LMSetMBarHeight(int16_t h);
 void CopyRgn(RgnHandle srcRgn, RgnHandle dstRgn);

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -88,8 +88,12 @@ NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<st
         id menuIdentifier = [[MCMenuItemIdentifier alloc] initWithRawIds:menu.menu_id itemId:itemId];
         [subMenuItem setRepresentedObject:menuIdentifier];
         subMenuItem.enabled = subMenuItemRes.enabled;
-        if (subMenuItemRes.checked) {
+        bool mark_is_submenu_link = (subMenuItemRes.key_equivalent == 0x1B);
+        char mark = mark_is_submenu_link ? 0 : subMenuItemRes.mark_character;
+        if (subMenuItemRes.checked || mark == 19) {
           subMenuItem.state = NSControlStateValueOn;
+        } else if (mark != 0) {
+          subMenuItem.state = NSControlStateValueMixed;
         }
 
         // Submenu ids are specified by the itemMark field if the itemCmd field has

--- a/src/realmz_orig/handlemenuchoice.c
+++ b/src/realmz_orig/handlemenuchoice.c
@@ -1050,5 +1050,8 @@ short HandleMenuChoice(void) {
       }
       break;
   }
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(chromancer): We have to force a sync here or we end up with menu items off by one. */
+  DrawMenuBar();
   return (0);
 }

--- a/src/realmz_orig/items.c
+++ b/src/realmz_orig/items.c
@@ -418,6 +418,9 @@ backup:
               gotegg = TRUE;
 
               MyrAppendMenu(copy, (Ptr) "The Packers Rock!");
+              /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+               * NOTE(chromancer): AppendMenu no longer syncs; sync before MenuSelect shows the bar. */
+              DrawMenuBar();
             }
             compactheap();
             menuChoice = MenuSelect(gTheEvent.where);

--- a/src/realmz_orig/menuinit.c
+++ b/src/realmz_orig/menuinit.c
@@ -318,4 +318,7 @@ neednewfile:
       lastload = -1;
     }
   }
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(chromancer): Sync once after sort is complete to prevent hangs. */
+  DrawMenuBar();
 }

--- a/src/realmz_orig/misc.c
+++ b/src/realmz_orig/misc.c
@@ -1775,6 +1775,9 @@ void updatemapmenu(void) {
     CheckItem(prefer, 7, 1);
   else
     CheckItem(prefer, 7, 0);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(chromancer): per-item menu ops no longer sync. Sync once after batch. */
+  DrawMenuBar();
 }
 
 /****************************** Startlevel **********************************/

--- a/src/realmz_orig/newland.c
+++ b/src/realmz_orig/newland.c
@@ -2395,8 +2395,10 @@ startover:
 
       case 29: /******* Give/Display Map *******/
         map[abs(id)] = TRUE;
-        updatemapmenu();
+        /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+         * NOTE(chromancer): set the mark before updatemapmenu so its sync flushes it too. */
         CheckItem(gScenario, abs(id) + 4, 1);
+        updatemapmenu();
         if (id > -1)
           flashmessage((StringPtr) "You gain a map, to view the map use Maps/Notes in the Menu.", 30, 355, 0, 30005);
         else

--- a/src/realmz_orig/partyloss.c
+++ b/src/realmz_orig/partyloss.c
@@ -85,6 +85,9 @@ void partyloss(short mode) {
   cleartarget();
   for (t = 1; t < 20; t++)
     DisableItem(gScenario, t + 3);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(chromancer): per-item menu ops no longer sync; sync after this batch. */
+  DrawMenuBar();
 
   if (mode)
     return;


### PR DESCRIPTION
combined add feature & hang fix here because they're dependent on one another.

issue: During work on adding menu item marks back (because once I put back the icons on the dropdowns it bothered me) I found cause of hang on tutorial, and fixing this also fixes sync on marks.

cause: anything that changed the main menu bar (checkitem, setitemmark, setmenuitemtext, etc.) called mm.sync which rebuilds the whole menu bar from scratch. The tutorial as a special case doesn't have the prebuilt menu data > runs a sort on the bestiary menu items to build it > every change rebuilds the menu bar very, very, very many times > indefinite hang. This was kind of a deadfall trap for future scenarios.

fix:

- strip syncs from those
- use existing DrawMenuBar sync instead.
- Requires us to add one additional DrawMenuBar in the original source, or item checks lag user actions by one (as in #149); I considered some other options but honestly this was simplest.
- finally, restored Cocoa rendering of dropped menu marks. 

notes: Diamonds are implemented with the dash (NSControlStateValueMixed).
I see no reason this wouldn't fix the tutorial hang on Windows but I've have done no testing.
No Windows marks yet.

Should fix #200. Partially addresses #202.