### PR TITLE
Fix non-functional volume/speed menus on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Show the selected level in the Windows Volume, Speed and Music menus by rendering item marks.
+  - CHANGED FROM ORIGINAL IMPLEMENTATION: native Windows menus have no "mixed" state, so every
+    nonzero mark glyph (19 diamond, -41 dash) collapses to a single checkmark.
+
 ## [v8.1.0-beta2](https://github.com/Realmz-Castle/realmz/releases/tag/v8.1.0-beta2)
 
 - Add CMake presets for macOS by @jpetrie in #167

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## Unreleased
-
-- Show the selected level in the Windows Volume, Speed and Music menus by rendering item marks.
-  - CHANGED FROM ORIGINAL IMPLEMENTATION: native Windows menus have no "mixed" state, so every
-    nonzero mark glyph (19 diamond, -41 dash) collapses to a single checkmark.
-
 ## [v8.1.0-beta2](https://github.com/Realmz-Castle/realmz/releases/tag/v8.1.0-beta2)
 
 - Add CMake presets for macOS by @jpetrie in #167

--- a/src/windows/MenuController.cpp
+++ b/src/windows/MenuController.cpp
@@ -35,10 +35,19 @@ void MCSync(std::shared_ptr<MenuList> menuList, void (*callback)(int16_t, int16_
 
   auto win_menu_list = std::make_shared<WinMenuList>();
 
-  auto menus = std::transform(
+  std::transform(
       menuList->menus.begin(),
       menuList->menus.end(),
       std::back_inserter(win_menu_list->menus),
+      win_menu_from_menu);
+
+  // Hierarchical menus (e.g. the Volume and Speed submenus) live in submenus and are
+  // referenced from a parent item via the 0x1B/mark_character marker. They must be carried
+  // across so WinMenuSync can attach them; otherwise those menus appear inert.
+  std::transform(
+      menuList->submenus.begin(),
+      menuList->submenus.end(),
+      std::back_inserter(win_menu_list->submenus),
       win_menu_from_menu);
 
   WinMenuSync(sdl_window.get(), win_menu_list, callback);

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -124,9 +124,15 @@ static HMENU BuildMenu(const std::shared_ptr<WinMenu>& menu, const WinMenuList& 
   uint16_t i = 1;
   for (const auto& submenu_item : menu->items) {
     UINT enabled_state = submenu_item.enabled ? MFS_ENABLED : MFS_DISABLED;
-    UINT checked_state = submenu_item.checked ? MFS_CHECKED : MFS_UNCHECKED;
 
     bool is_hierarchical = (submenu_item.key_equivalent == hMenuCmd) && submenu_item.mark_character;
+
+    // A non-submenu item carries its mark in mark_character (set via SetItemMark): 19 is the
+    // diamond "selected" glyph, -41 a secondary state. Native Windows menus have no "mixed"
+    // state, so collapse every nonzero mark to a check. Submenu parents store the child menu id
+    // in mark_character, so key_equivalent == 0x1B guards against treating that as a mark.
+    bool marked = submenu_item.checked || (!is_hierarchical && submenu_item.mark_character != 0);
+    UINT checked_state = marked ? MFS_CHECKED : MFS_UNCHECKED;
 
     std::string name = submenu_item.name;
     if (submenu_item.key_equivalent && !is_hierarchical) {

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -111,6 +111,54 @@ HWND get_window_handle(SDL_Window* sdl_window) {
       NULL));
 }
 
+// Classic Mac marks a menu item as the parent of a hierarchical submenu by setting its command
+// char (key_equivalent here) to 0x1B; the mark_character then holds the submenu's menu id.
+// Macintosh Toolbox Essentials (3-96).
+static constexpr char hMenuCmd = 0x1B;
+
+// Builds the Windows drop-down/submenu for a Realmz menu, recursing into any hierarchical
+// submenus (such as Volume and Speed) referenced via the 0x1B/mark_character marker.
+static HMENU BuildMenu(const std::shared_ptr<WinMenu>& menu, const WinMenuList& menu_list) {
+  HMENU win_submenu = CreateMenu();
+
+  uint16_t i = 1;
+  for (const auto& submenu_item : menu->items) {
+    UINT enabled_state = submenu_item.enabled ? MFS_ENABLED : MFS_DISABLED;
+    UINT checked_state = submenu_item.checked ? MFS_CHECKED : MFS_UNCHECKED;
+
+    bool is_hierarchical = (submenu_item.key_equivalent == hMenuCmd) && submenu_item.mark_character;
+
+    std::string name = submenu_item.name;
+    if (submenu_item.key_equivalent && !is_hierarchical) {
+      name += std::format("\tCtrl+{:c}", toupper(submenu_item.key_equivalent));
+    }
+
+    MENUITEMINFO submenu_info = MENUITEMINFO{
+        .cbSize = sizeof(MENUITEMINFO),
+        .fMask = MIIM_FTYPE | MIIM_ID | MIIM_STATE | MIIM_STRING,
+        .fType = MFT_STRING,
+        .fState = enabled_state | checked_state,
+        .wID = PackMenuIdentifier(menu->menu_id, i),
+        .dwTypeData = const_cast<char*>(name.c_str()),
+        .cch = static_cast<UINT>(name.length())};
+
+    // Attach the referenced submenu, if this item is a hierarchical-menu parent.
+    if (is_hierarchical) {
+      for (const auto& sub : menu_list.submenus) {
+        if (sub->menu_id == static_cast<uint8_t>(submenu_item.mark_character)) {
+          submenu_info.fMask |= MIIM_SUBMENU;
+          submenu_info.hSubMenu = BuildMenu(sub, menu_list);
+          break;
+        }
+      }
+    }
+
+    InsertMenuItem(win_submenu, i++, TRUE, &submenu_info);
+  }
+
+  return win_submenu;
+}
+
 void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list, void (*callback)(int16_t, int16_t)) {
   // Update current menu click callback function
   menuCallback = callback;
@@ -126,30 +174,8 @@ void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list,
       .fMask = MIM_APPLYTOSUBMENUS | MIM_STYLE};
   SetMenuInfo(win_menu, &win_menu_info);
 
-  uint16_t i;
   for (auto menu : menu_list->menus) {
-    auto submenu = CreateMenu();
-
-    i = 1;
-    for (const auto& submenu_item : menu->items) {
-      UINT enabled_state = submenu_item.enabled ? MFS_ENABLED : MFS_DISABLED;
-      UINT checked_state = submenu_item.checked ? MFS_CHECKED : MFS_UNCHECKED;
-
-      std::string name = submenu_item.name;
-      if (submenu_item.key_equivalent) {
-        name += std::format("\tCtrl+{:c}", toupper(submenu_item.key_equivalent));
-      }
-      MENUITEMINFO submenu_info = MENUITEMINFO{
-          .cbSize = sizeof(MENUITEMINFO),
-          .fMask = MIIM_FTYPE | MIIM_ID | MIIM_STATE | MIIM_STRING,
-          .fType = MFT_STRING,
-          .fState = enabled_state | checked_state,
-          .wID = PackMenuIdentifier(menu->menu_id, i),
-          .dwTypeData = const_cast<char*>(name.c_str()),
-          .cch = static_cast<UINT>(name.length())};
-
-      InsertMenuItem(submenu, i++, TRUE, &submenu_info);
-    }
+    auto submenu = BuildMenu(menu, *menu_list);
 
     MENUITEMINFO item_info = MENUITEMINFO{
         .cbSize = sizeof(MENUITEMINFO),


### PR DESCRIPTION
The Volume and Speed pickers did nothing on Windows because their Classic Mac hierarchical submenus were never built. MCSync copied only the top level menus and dropped MenuList::submenus, and the Windows menu builder laid each menu out as a flat list, ignoring the 0x1B/mark_character marker that links a parent item to its child menu, so there was no submenu to open.

This carries the submenus across in MCSync and adds a recursive BuildMenu that attaches each referenced submenu with MIIM_SUBMENU and suppresses the spurious Ctrl+0x1b accelerator the marker would otherwise create. It also renders item marks: now that SetItemMark stores the current selection in mark_character, BuildMenu draws a check on the marked Volume, Speed or Music level, collapsing the diamond and dash glyphs to a single check since native Windows menus have no mixed state.

The change is confined to src/windows, which compiles only under WIN32. macOS already builds these submenus and renders their marks in MenuController.mm and is left untouched, so both platforms keep working.

Closes #206. Related to #202.
