### PR TITLE
Add configurable window scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add configurable window scaling via a `settings.json` file next to the executable
+
 ## [v8.1.0-beta2](https://github.com/Realmz-Castle/realmz/releases/tag/v8.1.0-beta2)
 
 - Add CMake presets for macOS by @jpetrie in #167

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ set(SOURCES
     src/QuickDraw.cpp
     src/ResourceManager.cpp
     src/SDLHelpers.cpp
+    src/Settings.cpp
     src/SoundManager.cpp
     src/WindowManager.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,8 @@ if(APPLE)
     install(FILES ${DATA_RESOURCE_FILES} DESTINATION "Data Files")
     install(DIRECTORY "${CMAKE_SOURCE_DIR}/base/Realmz/Scenarios" DESTINATION ".")
     install(FILES ${CHARACTER_DATA_FILES} DESTINATION "Character Files")
+    # Default settings file, loaded from SDL_GetBasePath() (the Resources dir) at startup
+    install(FILES "${CMAKE_SOURCE_DIR}/settings.json" DESTINATION ".")
 
     # We dynamically link to the SDL* libraries (plus an asan lib that clang links against),
     # so we need to ensure that they get included in the bundle. MacOS supports rpaths, which
@@ -406,6 +408,8 @@ elseif(WIN32)
     install(FILES ${DATA_RESOURCE_FILES} DESTINATION "${CMAKE_INSTALL_BINDIR}/Data Files")
     install(DIRECTORY "base/Realmz/Scenarios" DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${CHARACTER_DATA_FILES} DESTINATION "${CMAKE_INSTALL_BINDIR}/Character Files")
+    # Default settings file, loaded from SDL_GetBasePath() (next to the exe) at startup
+    install(FILES "${CMAKE_SOURCE_DIR}/settings.json" DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     # CMake's RUNTIME_DEPENDENCIES argument to install should work to include necessary
     # runtime dlls alongside the Realmz executable, but unfortunately (as of 4.1.1) it does

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The game renders at its original 800x600 size, which can be small on a high reso
 }
 ```
 
-`scale` is a multiplier on the 800x600 window, so `2.0` produces a 1600x1200 window. Any value from `1.0` to `4.0` is allowed, including fractional values like `1.5`. `filter` controls how the image is scaled up: `auto` (the default) keeps the picture crisp at whole-number scales and smooths it at fractional ones, `nearest` is always crisp, and `linear` is always smooth. The file is optional; without it the game runs at 800x600 as before.
+`scale` is a multiplier on the 800x600 window, so `2.0` produces a 1600x1200 window. Any value from `1.0` to `4.0` is allowed, including fractional values like `1.5`. `filter` controls how the image is scaled up: `auto` (the default) uses sharp pixels at whole-number scales and a pixel-art filter at fractional ones to keep the text crisp; `nearest` is always sharp but can look uneven at fractional scales; `pixelart` stays sharp and even at any scale; and `linear` fully smooths the image, which softens the bitmap UI text. The file is optional; without it the game runs at 800x600 as before.
 
 # Reporting Bugs
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ On Mac, double click the `.dmg` file you downloaded, then click and drag the Rea
 
 On Windows, you can either use the installer wizard for automatic installation, or a ZIP archive for custom installations. To use the installer, double click the `.exe` you downloaded. Accept the license agreement, choose an install location for Realmz, and continue through the "components" section of the installer.
 
+# Settings
+
+The game renders at its original 800x600 size, which can be small on a high resolution display. To make the window larger, create a file named `settings.json` next to the Realmz executable (the same folder as `Realmz.exe` on Windows, or inside the application bundle on Mac):
+
+```json
+{
+  "scaling": {
+    "scale": 2.0,
+    "filter": "auto"
+  }
+}
+```
+
+`scale` is a multiplier on the 800x600 window, so `2.0` produces a 1600x1200 window. Any value from `1.0` to `4.0` is allowed, including fractional values like `1.5`. `filter` controls how the image is scaled up: `auto` (the default) keeps the picture crisp at whole-number scales and smooths it at fractional ones, `nearest` is always crisp, and `linear` is always smooth. The file is optional; without it the game runs at 800x600 as before.
+
 # Reporting Bugs
 
 - Save the crash report file (if possible)

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,15 @@
+// Realmz settings. Edit the values below and restart the game.
+{
+  "scaling": {
+    // "scale" is a size multiplier applied to the original 800x600 window.
+    // 1.0 keeps the original size, 2.0 makes the window 1600x1200, and so on.
+    // Any value from 1.0 to 4.0 is allowed, including fractional ones like 1.5.
+    "scale": 1.0,
+
+    // "filter" controls how the image is scaled up to fill the window:
+    //   "auto"    - crisp at whole-number scales, smooth at fractional ones (default)
+    //   "nearest" - always crisp, with blocky pixels
+    //   "linear"  - always smooth, with softer edges
+    "filter": "auto"
+  }
+}

--- a/settings.json
+++ b/settings.json
@@ -7,9 +7,10 @@
     "scale": 1.0,
 
     // "filter" controls how the image is scaled up to fill the window:
-    //   "auto"    - crisp at whole-number scales, smooth at fractional ones (default)
-    //   "nearest" - always crisp, with blocky pixels
-    //   "linear"  - always smooth, with softer edges
+    //   "auto"     - nearest at whole-number scales, pixelart at fractional ones (default)
+    //   "nearest"  - sharp pixels, but uneven widths at fractional scales
+    //   "pixelart" - sharp text and edges that stay even at fractional scales
+    //   "linear"   - fully smoothed; softens the bitmap UI text
     "filter": "auto"
   }
 }

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -1,6 +1,7 @@
 #include "EventManager.h"
 
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_render.h>
 
 #include <cstring>
 #include <deque>
@@ -413,7 +414,18 @@ protected:
     em_log.debug_f("Enqueued event (what={}, message=0x{:08X}, when=0x{:08X}, where=(h={}, v={}), modifiers=0x{:04X})", name_for_event_type(ev.what), ev.message, ev.when, ev.where.h, ev.where.v, ev.modifiers);
   }
 
-  void enqueue_sdl_event(const SDL_Event& e) {
+  void enqueue_sdl_event(const SDL_Event& original_event) {
+    // Convert window pixel coordinates into the 800x600 logical coordinates the
+    // game renders in. When the window is scaled up, SDL reports mouse positions
+    // in window pixels; this maps them back so clicks land on the right spot.
+    // Non-positional events (keys, etc.) are passed through unchanged.
+    SDL_Event e = original_event;
+    if (auto window = WindowManager::instance().get_sdl_window()) {
+      if (auto renderer = SDL_GetRenderer(window.get())) {
+        SDL_ConvertEventToRenderCoordinates(renderer, &e);
+      }
+    }
+
     switch (e.type) {
       // TODO: Handle any cleanup of specific window that was closed
       //  case SDL_EVENT_WINDOW_CLOSE_REQUESTED:

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,71 @@
+#include "Settings.hpp"
+
+#include <SDL3/SDL_filesystem.h>
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+#include <phosg/Filesystem.hh>
+#include <phosg/JSON.hh>
+#include <phosg/Strings.hh>
+
+#include "Types.hpp"
+
+static phosg::PrefixedLogger settings_log("[Settings] ", DEFAULT_LOG_LEVEL);
+
+// Keep the window between original size and 4x so a stray value can't produce a
+// window larger than any reasonable display.
+static constexpr float MIN_SCALE = 1.0f;
+static constexpr float MAX_SCALE = 4.0f;
+
+RealmzSettings load_realmz_settings() {
+  RealmzSettings settings;
+
+  const char* base_path = SDL_GetBasePath();
+  if (!base_path) {
+    settings_log.warning_f("Could not get base path: {}; using default window settings", SDL_GetError());
+    return settings;
+  }
+  std::string path = std::string(base_path) + "settings.json";
+
+  std::string data;
+  try {
+    data = phosg::load_file(path);
+  } catch (const std::exception& e) {
+    // No settings file is the normal case, so this is not a warning.
+    settings_log.info_f("Could not read {} ({}); using default window settings", path, e.what());
+    return settings;
+  }
+
+  try {
+    auto root = phosg::JSON::parse(data);
+    phosg::JSON empty_dict = phosg::JSON::dict();
+    const phosg::JSON& scaling = root.get("scaling", empty_dict);
+
+    double scale = scaling.get_float("scale", 1.0);
+    settings.scale = std::clamp(static_cast<float>(scale), MIN_SCALE, MAX_SCALE);
+
+    std::string filter = scaling.get_string("filter", "auto");
+    if (filter == "nearest") {
+      settings.scale_mode = SDL_SCALEMODE_NEAREST;
+    } else if (filter == "linear") {
+      settings.scale_mode = SDL_SCALEMODE_LINEAR;
+    } else {
+      if (filter != "auto") {
+        settings_log.warning_f("Unknown filter '{}'; using auto", filter);
+      }
+      // auto: nearest for whole-number scales keeps the pixel art crisp;
+      // fractional scales use linear to avoid unevenly sized pixels.
+      bool is_integer_scale = (settings.scale == std::floor(settings.scale));
+      settings.scale_mode = is_integer_scale ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR;
+    }
+  } catch (const std::exception& e) {
+    settings_log.warning_f("Could not parse {} ({}); using default window settings", path, e.what());
+    return RealmzSettings{};
+  }
+
+  settings_log.info_f("Window scale {}x, filter {}", settings.scale,
+      (settings.scale_mode == SDL_SCALEMODE_NEAREST) ? "nearest" : "linear");
+  return settings;
+}

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -51,21 +51,27 @@ RealmzSettings load_realmz_settings() {
       settings.scale_mode = SDL_SCALEMODE_NEAREST;
     } else if (filter == "linear") {
       settings.scale_mode = SDL_SCALEMODE_LINEAR;
+    } else if (filter == "pixelart") {
+      settings.scale_mode = SDL_SCALEMODE_PIXELART;
     } else {
       if (filter != "auto") {
         settings_log.warning_f("Unknown filter '{}'; using auto", filter);
       }
-      // auto: nearest for whole-number scales keeps the pixel art crisp;
-      // fractional scales use linear to avoid unevenly sized pixels.
+      // auto: whole-number scales are pixel-perfect with nearest. Fractional
+      // scales use the pixel-art mode, which keeps the bitmap fonts crisp while
+      // scaling cleanly; plain linear blurs them and plain nearest makes the
+      // pixels unevenly sized.
       bool is_integer_scale = (settings.scale == std::floor(settings.scale));
-      settings.scale_mode = is_integer_scale ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR;
+      settings.scale_mode = is_integer_scale ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_PIXELART;
     }
   } catch (const std::exception& e) {
     settings_log.warning_f("Could not parse {} ({}); using default window settings", path, e.what());
     return RealmzSettings{};
   }
 
-  settings_log.info_f("Window scale {}x, filter {}", settings.scale,
-      (settings.scale_mode == SDL_SCALEMODE_NEAREST) ? "nearest" : "linear");
+  const char* mode_name = (settings.scale_mode == SDL_SCALEMODE_NEAREST) ? "nearest"
+      : (settings.scale_mode == SDL_SCALEMODE_LINEAR)                    ? "linear"
+                                                                        : "pixelart";
+  settings_log.info_f("Window scale {}x, filter {}", settings.scale, mode_name);
   return settings;
 }

--- a/src/Settings.hpp
+++ b/src/Settings.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <SDL3/SDL_surface.h>
+
+// Settings loaded from settings.json in the directory containing the
+// executable. The game always renders into a fixed 800x600 logical buffer;
+// these control how that buffer is presented to the screen so the window can
+// be larger than 800x600 on modern displays.
+struct RealmzSettings {
+  // Window size multiplier applied to the 800x600 logical size. 1.0 keeps the
+  // original size. Clamped to a sane range when loaded.
+  float scale = 1.0f;
+  // Texture filter used when the logical buffer is scaled up to the window.
+  SDL_ScaleMode scale_mode = SDL_SCALEMODE_NEAREST;
+};
+
+// Loads settings.json from the directory containing the executable. Any problem
+// (missing file, parse failure, out-of-range values) falls back to defaults.
+RealmzSettings load_realmz_settings();

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -2,6 +2,7 @@
 
 #include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_properties.h>
+#include <cmath>
 #include <memory>
 #include <stdexcept>
 
@@ -938,16 +939,29 @@ WindowManager::~WindowManager() = default;
 void WindowManager::create_sdl_window() {
   wm_log.debug_f("WindowManager::create_sdl_window()");
 
-  static constexpr size_t w = 800;
-  static constexpr size_t h = 600;
-  this->sdl_window = sdl_make_shared(SDL_CreateWindow("Realmz", w, h, 0));
+  // The game always renders into an 800x600 logical buffer. The settings file
+  // can scale the window up; SDL then scales the logical buffer to fill it, so
+  // no game-side coordinates need to change.
+  static constexpr int logical_w = 800;
+  static constexpr int logical_h = 600;
+
+  this->settings = load_realmz_settings();
+  int window_w = std::lround(logical_w * this->settings.scale);
+  int window_h = std::lround(logical_h * this->settings.scale);
+
+  this->sdl_window = sdl_make_shared(SDL_CreateWindow("Realmz", window_w, window_h, 0));
   if (!this->sdl_window) {
     throw std::runtime_error(std::format("Could not create SDL window: {}", SDL_GetError()));
   }
-  if (!SDL_CreateRenderer(this->sdl_window.get(), nullptr)) {
+  auto renderer = SDL_CreateRenderer(this->sdl_window.get(), nullptr);
+  if (!renderer) {
     throw std::runtime_error(std::format("Could not create window renderer: {}", SDL_GetError()));
   }
-  this->screen_port.resize(w, h);
+  // Present in 800x600 logical coordinates regardless of the window size. The
+  // multiplier scales both axes equally so the 4:3 aspect ratio is preserved.
+  SDL_SetRenderLogicalPresentation(renderer, logical_w, logical_h, SDL_LOGICAL_PRESENTATION_LETTERBOX);
+
+  this->screen_port.resize(logical_w, logical_h);
   this->recomposite_all();
 }
 
@@ -1187,6 +1201,8 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
         if (!texture) {
           wm_log.error_f("Could not create texture: {}", SDL_GetError());
         } else {
+          SDL_SetTextureScaleMode(texture.get(), this->settings.scale_mode);
+          SDL_RenderClear(renderer);
           SDL_RenderTexture(renderer, texture.get(), nullptr, nullptr);
         }
       }

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -9,6 +9,7 @@
 
 #include "QuickDraw.hpp"
 #include "SDLHelpers.hpp"
+#include "Settings.hpp"
 
 class WindowManager;
 class Window;
@@ -99,6 +100,7 @@ private:
   std::shared_ptr<Window> top_window;
   std::shared_ptr<Window> bottom_window;
   sdl_window_shared sdl_window;
+  RealmzSettings settings;
   bool text_editing_active = false;
   bool recomposite_enabled = true;
 

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -120,6 +120,13 @@ void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list,
 
   auto wind_handle = get_window_handle(sdl_window);
 
+  // Capture the current content size before touching the menu. Adding the menu
+  // bar shrinks the client area without SDL knowing, so we restore this size
+  // afterwards. On the first sync this is the size the window was created at
+  // (the configured scale); on later syncs it is the size restored previously.
+  int client_w, client_h;
+  SDL_GetWindowSize(sdl_window, &client_w, &client_h);
+
   HMENU win_menu = CreateMenu();
   MENUINFO win_menu_info = MENUINFO{
       .cbSize = sizeof(MENUINFO),
@@ -182,8 +189,8 @@ void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list,
   // bypass SDL to create the menu directly via the Windows API, it seems that SDL doesn't know that
   // the rendering of the menu bar has shrunk the client area. So, a quick call to SDL_SetWindowSize is
   // enough to force SDL to realize the menu bar now exists and to expand the window to ensure that the
-  // client area is the full 800x600.
-  SDL_SetWindowSize(sdl_window, 800, 600);
+  // client area is the full size captured above.
+  SDL_SetWindowSize(sdl_window, client_w, client_h);
 }
 
 int WinCreatePopupMenu(SDL_Window* sdl_window, std::shared_ptr<WinMenu> menu) {


### PR DESCRIPTION
See this github issue: #158

Realmz renders at a fixed 800x600 normally and is pretty small on modern displays. This adds an optional settings.json next to the executable with a scale multiplier and a filter. It uses a settings file rather than new in-game menu options to keep the classic menus unchanged. The default ships with scale 1.0, so nothing changes unless a player edits it.

The game still renders into its 800x600 buffer; only the final present is scaled via SDL logical presentation, and mouse input is converted back so clicks stay accurate. The filter controls the upscale (auto, nearest, pixelart, linear); auto keeps the bitmap fonts crisp. It stays macOS and Windows compatible: the scaling is cross-platform SDL, and the only platform-specific change restores the Windows client area after the native menu bar is added.

Three options to compare below. IMO pixel art at 1.5x is my personal preference here though linear does make the quest text look better but the "Items" and "Conditions" bitmap font buttons worse. Open each image in a new tab in order and tab between them:
```
    "scale": 1.5,
    "filter": "nearest"
```

<img width="1202" height="952" alt="image" src="https://github.com/user-attachments/assets/8ad84709-85db-4295-b316-fe6dee47f5c0" />

```
    "scale": 1.5,
    "filter": "pixelart"
```

<img width="1202" height="952" alt="image" src="https://github.com/user-attachments/assets/366f831c-bb2c-4925-89a8-33f4e8643067" />

```
    "scale": 1.5,
    "filter": "linear"
```

<img width="1202" height="952" alt="image" src="https://github.com/user-attachments/assets/64196862-2b58-46c7-9aba-35e3bb0839a1" />
