### PR TITLE
SDL #13134 fix

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -343,6 +343,10 @@ public:
     this->modifier_flags |= EVMOD_MOUSE_BUTTON_UP;
   }
 
+  void expect_orphan_mouseup() {
+    this->expecting_orphan_mouseup = true;
+  }
+
   inline const Point& get_mouse_loc() const {
     return this->mouse_loc;
   }
@@ -372,6 +376,7 @@ protected:
   Point mouse_loc = {0, 0};
   uint16_t modifier_flags = EVMOD_MOUSE_BUTTON_UP | EVMOD_WINDOW_ACTIVATED;
   std::deque<EventRecord> event_queue;
+  bool expecting_orphan_mouseup = false;
 
   void set_modifier_value(uint16_t what, bool enabled) {
     if (enabled) {
@@ -480,8 +485,16 @@ protected:
         if (e.button.button == 1) {
           this->mouse_loc.h = e.button.x;
           this->mouse_loc.v = e.button.y;
-          this->set_modifier_value(EVMOD_MOUSE_BUTTON_UP, (e.type == SDL_EVENT_MOUSE_BUTTON_UP));
           auto window = WindowManager::instance().window_for_point(this->mouse_loc.h, this->mouse_loc.v);
+          // SDL#13134: native popup eats the mouseDown; synthesize it from the lone mouseUp (single-shot).
+          if (this->expecting_orphan_mouseup) {
+            this->expecting_orphan_mouseup = false;
+            if (e.type == SDL_EVENT_MOUSE_BUTTON_UP) {
+              this->set_modifier_value(EVMOD_MOUSE_BUTTON_UP, false);
+              this->enqueue_event(mouseDown, 0, window ? &window->get_port() : nullptr, "");
+            }
+          }
+          this->set_modifier_value(EVMOD_MOUSE_BUTTON_UP, (e.type == SDL_EVENT_MOUSE_BUTTON_UP));
           this->enqueue_event((e.type == SDL_EVENT_MOUSE_BUTTON_DOWN) ? mouseDown : mouseUp, 0, window ? &window->get_port() : nullptr, "");
         }
         break;
@@ -609,4 +622,8 @@ void PushMenuEvent(int16_t menu_id, int16_t item_id) {
 
 void reset_mouse_state() {
   em.reset_mouse_state();
+}
+
+void expect_orphan_mouseup() {
+  em.expect_orphan_mouseup();
 }

--- a/src/EventManager.h
+++ b/src/EventManager.h
@@ -95,6 +95,7 @@ void FlushEvents(int16_t mask, uint16_t stop_mask); // IM2-69
 Boolean WaitNextEvent(int16_t mask, EventRecord* ev, uint32_t sleep, RgnHandle mouse_rgn);
 
 void reset_mouse_state();
+void expect_orphan_mouseup();
 
 #ifdef __cplusplus
 }

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -274,6 +274,10 @@ int32_t PopUpMenuSelect(MenuHandle menu, int16_t top, int16_t left, int16_t popU
   auto nsWindow = SDL_GetPointerProperty(properties, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
 
   result = -1;
+#if defined(__APPLE__)
+  // SDL#13134 is Mac-only.
+  expect_orphan_mouseup();
+#endif
   MCCreatePopupMenu(nsWindow, m, {top, left}, &popupCallback);
 
   // Wait for either an item to be selected and fire the callback to modify result, or for


### PR DESCRIPTION
issue: after using a Mac native popup menu (class, race, condition, etc.), next mouse click does nothing

cause: when a popup opens on mouse-down, macOS routes mouse-up to menu, not app. SDL mishandles, assumes button still held, eats next click. See SDL bug [#13134](https://github.com/libsdl-org/SDL/issues/13134)

fix: on Mac only, flag before opening popup and fake a mousedown if necessary

effects and thoughts: kludge required by our vendored SDL (dev snapshot). SDL already fixed in 3.4.0 ([commit 92eaa34](https://github.com/libsdl-org/SDL/commit/92eaa34277f0711696d366742735fe2a2c974123)).

Alternatively, we could just bump SDL, which contrary to my expectations doesn't seem like a big deal here. I'm gonna do it in my build and see what happens.

testing: Fixes for MacOS 26.5.1, all other platforms opted out.