### PR TITLE
Load saved games in windows  from the original retail Realmz on MacOS 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Load saved games created by the original retail Realmz. These store the cancamp field as 10 shorts, making them 18 bytes larger than the saves this port wrote, so they were previously rejected. The port now reads that format and writes it as well.
+- Load saved games created by the original retail Realmz. These store the cancamp field as 10 shorts, making them 18 bytes larger than the saves this port wrote, so they were previously rejected. The port now reads that format and writes it as well. The bank balance and temple cost in those saves are also now byteswapped correctly, so they no longer load as huge garbage values on a little-endian machine.
 
 ## [v8.1.0-beta2](https://github.com/Realmz-Castle/realmz/releases/tag/v8.1.0-beta2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-- Load saved games created by the original retail Realmz. These store the cancamp field as 10 shorts, making them 18 bytes larger than the saves this port wrote, so they were previously rejected. The port now reads that format and writes it as well. The bank balance and temple cost in those saves are also now byteswapped correctly, so they no longer load as huge garbage values on a little-endian machine.
-
 ## [v8.1.0-beta2](https://github.com/Realmz-Castle/realmz/releases/tag/v8.1.0-beta2)
 
 - Add CMake presets for macOS by @jpetrie in #167

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Load saved games created by the original retail Realmz. These store the cancamp field as 10 shorts, making them 18 bytes larger than the saves this port wrote, so they were previously rejected. The port now reads that format and writes it as well.
+
 ## [v8.1.0-beta2](https://github.com/Realmz-Castle/realmz/releases/tag/v8.1.0-beta2)
 
 - Add CMake presets for macOS by @jpetrie in #167

--- a/src/realmz_orig/loadsavedgame.c
+++ b/src/realmz_orig/loadsavedgame.c
@@ -120,18 +120,20 @@ short load(void) {
   fseek(fp, 0, SEEK_SET);
   // The original retail builds wrote `cancamp` as an array of 10 shorts (20 bytes) even though it is a single short.
   // This was a buffer overflow, but it is part of the on-disk format: those saves are 18 bytes larger than the ones
-  // this port writes by default. Detect that variant by file size so retail Mac/PC saves load correctly.
+  // this port writes by default. Detect that variant by file size so retail Mac saves load correctly. Those saves also
+  // store the `bank` and `templecost` fields big-endian like every other multi-byte field (see below), so the same flag
+  // gates the byte swap for them.
   int use_extended_long_format;
-  int use_original_cancamp;
+  int use_original_format;
   if (file_size == 0x3979) { // Modern Realmz Classic format (cancamp as a single short)
     use_extended_long_format = 0;
-    use_original_cancamp = 0;
+    use_original_format = 0;
   } else if (file_size == 0x398B) { // Original retail format (cancamp as 10 shorts)
     use_extended_long_format = 0;
-    use_original_cancamp = 1;
+    use_original_format = 1;
   } else if (file_size == 0x398D) {
     use_extended_long_format = 1;
-    use_original_cancamp = 0;
+    use_original_format = 0;
   } else {
     scratch2(7);
   }
@@ -320,13 +322,24 @@ short load(void) {
   // Thankfully, it seems Myriad forgot to byteswap these fields, so we do actually get the low 32 bits of the gems
   // value in the incorrect case, but the jewelry value is entirely lost. To recover from this, we can simply move the
   // jewelry value to gems, and clear the jewelry value. (Sorry about that!)
+  //
+  // The original retail Mac builds also forgot to byteswap bank (and templecost below), but those saves are big-endian,
+  // so on a little-endian host the values come out wildly wrong (a small bank balance reads as billions). Every other
+  // multi-byte field here is stored big-endian and converted with Cvt*ToPc, so do the same for these when reading the
+  // original format. The port's own little-endian saves are left as-is.
   fread(&bank, sizeof(int32_t), 3, fp); //*** fantasoft v7.1b  broke it up so work on PC side
+  if (use_original_format) {
+    CvtTabLongToPc(&bank, 3);
+  }
   if (use_extended_long_format) {
     bank[1] = bank[2];
     bank[2] = 0;
   }
 
   fread(&templecost, sizeof(short), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
+  if (use_original_format) {
+    CvtShortToPc(&templecost);
+  }
   fread(&inboat, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
   fread(&boatright, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
   fread(&canencounter, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
@@ -368,12 +381,12 @@ short load(void) {
    * as the comments speculate. cancamp is a scalar short variable, while these calls
    * seem to think it is an array of 10 shorts. This was causing buffer overflows.
    *
-   * The original retail saves do store 10 shorts here (use_original_cancamp), so read them
+   * The original retail saves do store 10 shorts here (use_original_format), so read them
    * into a local buffer and keep only the first value to avoid the overflow.
    */
   // fread(&cancamp, sizeof cancamp, 10, fp);
   // CvtTabShortToPc(&cancamp, 10); // Myriad ????
-  if (use_original_cancamp) {
+  if (use_original_format) {
     short cancamparray[10];
     fread(cancamparray, sizeof(short), 10, fp);
     CvtShortToPc(&cancamparray[0]);

--- a/src/realmz_orig/loadsavedgame.c
+++ b/src/realmz_orig/loadsavedgame.c
@@ -118,11 +118,12 @@ short load(void) {
   fseek(fp, 0, SEEK_END);
   size_t file_size = ftell(fp);
   fseek(fp, 0, SEEK_SET);
-  // The original retail builds wrote `cancamp` as an array of 10 shorts (20 bytes) even though it is a single short.
-  // This was a buffer overflow, but it is part of the on-disk format: those saves are 18 bytes larger than the ones
-  // this port writes by default. Detect that variant by file size so retail Mac saves load correctly. Those saves also
-  // store the `bank` and `templecost` fields big-endian like every other multi-byte field (see below), so the same flag
-  // gates the byte swap for them.
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * The original retail builds wrote `cancamp` as an array of 10 shorts (20 bytes) even though it is a single short.
+   * This was a buffer overflow, but it is part of the on-disk format: those saves are 18 bytes larger than the ones
+   * this port writes by default. Detect that variant by file size so retail Mac saves load correctly. Those saves also
+   * store the `bank` and `templecost` fields big-endian like every other multi-byte field (see below), so the same flag
+   * gates the byte swap for them. */
   int use_extended_long_format;
   int use_original_format;
   if (file_size == 0x3979) { // Modern Realmz Classic format (cancamp as a single short)
@@ -137,6 +138,7 @@ short load(void) {
   } else {
     scratch2(7);
   }
+  /* *** END CHANGES *** */
 
 // Fantasoft v7.0 Begin   I don't want the PC and Mac saved games to be compatible so I switched the save order of
 // Some important data to keep them from being compatible

--- a/src/realmz_orig/loadsavedgame.c
+++ b/src/realmz_orig/loadsavedgame.c
@@ -118,11 +118,20 @@ short load(void) {
   fseek(fp, 0, SEEK_END);
   size_t file_size = ftell(fp);
   fseek(fp, 0, SEEK_SET);
+  // The original retail builds wrote `cancamp` as an array of 10 shorts (20 bytes) even though it is a single short.
+  // This was a buffer overflow, but it is part of the on-disk format: those saves are 18 bytes larger than the ones
+  // this port writes by default. Detect that variant by file size so retail Mac/PC saves load correctly.
   int use_extended_long_format;
-  if (file_size == 0x3979) { // Original build format, or modern Realmz Classic format
+  int use_original_cancamp;
+  if (file_size == 0x3979) { // Modern Realmz Classic format (cancamp as a single short)
     use_extended_long_format = 0;
+    use_original_cancamp = 0;
+  } else if (file_size == 0x398B) { // Original retail format (cancamp as 10 shorts)
+    use_extended_long_format = 0;
+    use_original_cancamp = 1;
   } else if (file_size == 0x398D) {
     use_extended_long_format = 1;
+    use_original_cancamp = 0;
   } else {
     scratch2(7);
   }
@@ -358,11 +367,21 @@ short load(void) {
    * NOTE(danapplegate): This appears to have been a bug, possibly introduced by Myriad
    * as the comments speculate. cancamp is a scalar short variable, while these calls
    * seem to think it is an array of 10 shorts. This was causing buffer overflows.
+   *
+   * The original retail saves do store 10 shorts here (use_original_cancamp), so read them
+   * into a local buffer and keep only the first value to avoid the overflow.
    */
   // fread(&cancamp, sizeof cancamp, 10, fp);
   // CvtTabShortToPc(&cancamp, 10); // Myriad ????
-  fread(&cancamp, sizeof cancamp, 1, fp);
-  CvtTabShortToPc(&cancamp, 1); // Myriad ????
+  if (use_original_cancamp) {
+    short cancamparray[10];
+    fread(cancamparray, sizeof(short), 10, fp);
+    CvtShortToPc(&cancamparray[0]);
+    cancamp = cancamparray[0];
+  } else {
+    fread(&cancamp, sizeof cancamp, 1, fp);
+    CvtTabShortToPc(&cancamp, 1); // Myriad ????
+  }
   /* *** END CHANGES *** */
 
   fread(&storage, sizeof storage, 1, fp);

--- a/src/realmz_orig/save-direction-order.c
+++ b/src/realmz_orig/save-direction-order.c
@@ -439,13 +439,20 @@ void save(short mode) {
    * NOTE(danapplegate): This appears to have been a bug, possibly introduced by Myriad
    * as the comments speculate. cancamp is a scalar short variable, while these calls
    * seem to think it is an array of 10 shorts. This was causing buffer overflows.
+   *
+   * The original retail saves store 10 shorts here, so write the value plus zero padding
+   * out of a local buffer. This keeps our saves the same size as the originals and avoids
+   * the overflow of reading past the single cancamp variable.
    */
   // CvtTabShortToPc(&cancamp, 10); // Myriad ????
   // fwrite(&cancamp, sizeof cancamp, 10, fp);
   // CvtTabShortToPc(&cancamp, 10); // Myriad ????
-  CvtTabShortToPc(&cancamp, 1); // Myriad ????
-  fwrite(&cancamp, sizeof cancamp, 1, fp);
-  CvtTabShortToPc(&cancamp, 1); // Myriad ????
+  {
+    short cancamparray[10] = {0};
+    cancamparray[0] = cancamp;
+    CvtShortToPc(&cancamparray[0]);
+    fwrite(cancamparray, sizeof(short), 10, fp);
+  }
   /* *** END CHANGES *** */
 
   CvtTabItemToPc(&storage, 6);

--- a/src/realmz_orig/save-direction-order.c
+++ b/src/realmz_orig/save-direction-order.c
@@ -395,10 +395,17 @@ void save(short mode) {
   fwrite(&bankavailable, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
 
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-   * See note in main.c about sizeof(long) vs. sizeof(int32_t). */
+   * See note in main.c about sizeof(long) vs. sizeof(int32_t).
+   * The original code did not byteswap bank or templecost, which stored them in host byte order and made the values
+   * unreadable on a different-endian machine. Store them big-endian like every other multi-byte field so the saves
+   * match the original Mac format and load correctly; the loader converts them back. */
+  CvtTabLongToPc(&bank, 3);
   fwrite(&bank, sizeof(int32_t), 3, fp); //*** fantasoft v7.1b  broke it up so work on PC side
+  CvtTabLongToPc(&bank, 3);
 
+  CvtShortToPc(&templecost);
   fwrite(&templecost, sizeof(short), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
+  CvtShortToPc(&templecost);
   fwrite(&inboat, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
   fwrite(&boatright, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side
   fwrite(&canencounter, sizeof(char), 1, fp); //*** fantasoft v7.1b  broke it up so work on PC side


### PR DESCRIPTION
Saved games created by the original retail Realmz fail to load: the loader rejects their "Data I1" file with "error 7" because it does not match either known size.

These saves store the single-short `cancamp` field as an array of 10 shorts, an original buffer overflow that is part of the on-disk format, so the file is 18 bytes larger (`0x398B` instead of `0x3979`). Separately, `bank` and `templecost` are the only multi-byte fields the original code never byteswaps; the data is big-endian, so on a little-endian build they load as huge garbage values (a few-thousand-gold bank reads as billions).

Detect the larger format by size and read `cancamp` as 10 shorts into a local buffer, keeping only the first value to avoid the overflow. Byteswap `bank` and `templecost` when reading that format, and write both the 10-short `cancamp` and big-endian `bank`/`templecost` when saving so the layout matches the original and round-trips. Saves written by earlier versions of this port still load. Every other multi-byte field already uses the same big-endian helpers, so macOS and Windows builds behave identically.