### PR TITLE
menucontroller gets automatic memory management back

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ set(realmz_lib_LINK_LIBRARIES
 
 if(APPLE)
     list(APPEND SOURCES src/macos/MenuController.mm)
+    set_source_files_properties(src/macos/MenuController.mm PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
     list(APPEND realmz_lib_LINK_LIBRARIES
         "-framework Foundation"
         "-framework Cocoa"

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -230,7 +230,7 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
   }
 
   // In the Cocoa framework, the origin is the bottom left. The point p is passed to us as (top, left).
-  NSWindow* window = (NSWindow*)nsWindow;
+  NSWindow* window = (__bridge NSWindow*)nsWindow;
   NSView* view = window.contentView;
   NSSize size = view.frame.size;
   NSPoint loc = NSMakePoint(p.second, size.height - p.first);


### PR DESCRIPTION
issue: general latency climbs as game plays on Mac. when Josh pointed out that #235 needed more draws, I instrumented it and found it grew even when #-of-syncs didn't.

cause: menu-driven again, it's #209. Xcode defaults ARC on, cmake defaults MRC. with no release, sync time climbs from 4ms each to 21ms each in ~3m of starting CoB.

fix:

* turn on ARC for the file (-fobjc-arc)
* add one __bridge for ARC

effects: time per sync is now 4ms flat. tested on Tahoe 26.5.1