### PR TITLE
Show the dragged item icon in the shop

### DIFF
--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -1221,6 +1221,15 @@ void HideCursor(void) {
 }
 
 void ShowCursor(void) {
+  // On Classic Mac OS, ShowCursor never raises the cursor level above its
+  // visible state; a ShowCursor with the cursor already fully shown does
+  // nothing. The original game calls ShowCursor in many more places than
+  // HideCursor, so without this clamp the level drifts negative and a later
+  // HideCursor (for example, when dragging an item in the shop) becomes a
+  // no-op, leaving the cursor visible when it should be hidden.
+  if (cursor_hide_level == 0) {
+    return;
+  }
   cursor_hide_level--;
   if (cursor_hide_level == 0) {
     SDL_ShowCursor();

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1166,6 +1166,10 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
     }
   }
 
+  this->present_screen();
+}
+
+void WindowManager::present_screen() {
   if (this->sdl_window) {
     auto renderer = SDL_GetRenderer(this->sdl_window.get());
     if (!renderer) {
@@ -1931,6 +1935,10 @@ int WindowManager_SetEnableRecomposite(int enable) {
 void WindowManager_RecompositeAlways() {
   auto& wm = WindowManager::instance();
   wm.set_enable_recomposite(wm.set_enable_recomposite(true));
+}
+
+void WindowManager_PresentScreen() {
+  WindowManager::instance().present_screen();
 }
 
 TEHandle TENew(const Rect* destRect, const Rect* viewRect) {

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -150,6 +150,12 @@ void TEScroll(int16_t dh, int16_t dv, TEHandle hTE);
 int WindowManager_SetEnableRecomposite(int enable);
 void WindowManager_RecompositeAlways();
 
+// Presents the current screen buffer to the window without recompositing. Used
+// to make transient graphics drawn directly onto the screen (such as a dragged
+// item icon) visible. None of the callsites of this function are part of the
+// original source.
+void WindowManager_PresentScreen(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -132,6 +132,13 @@ public:
   void recomposite(std::shared_ptr<Window> updated_window);
   bool set_enable_recomposite(bool enable);
 
+  // Uploads the current contents of screen_port to the SDL window and presents
+  // it, without recompositing the window stack first. This is used by code that
+  // draws transient graphics directly onto the screen buffer (for example, an
+  // item icon dragged by the mouse in the shop), where recompositing would
+  // immediately erase those graphics.
+  void present_screen();
+
   // Recomposites the window stack, starting with the given window. Windows below
   // the given window are not recomposited. Updates the SDL window with the
   // rendered result.

--- a/src/realmz_orig/moveicon.c
+++ b/src/realmz_orig/moveicon.c
@@ -27,7 +27,7 @@ void itemcost(short mode) /****** 1 = sell, else buy ****/
 void moveicon(void) {
   float charge1, charge2 = 0;
   short valu, max, tempshop;
-  Rect iconpict, iconnp, iconop, iconstore, store;
+  Rect iconpict, iconnp, iconop, iconstore, store, storebg;
   Point oldpoint;
   Boolean empty = 0;
   Boolean doupdateshop = 0;
@@ -36,6 +36,7 @@ void moveicon(void) {
   short leftvalue, temp;
   struct itemattr tempitem;
   Boolean baditem = 0;
+  Boolean haveold = 0;
   int index;
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
    * NOTE(danapplegate): It seems that the global screen buffer was directly accessible. We've
@@ -43,7 +44,13 @@ void moveicon(void) {
    */
   BitMap* src;
   BitMap* dst = GetPortBitMapForCopyBits(gedge);
+  BitMap* bgbuf = GetPortBitMapForCopyBits(gbuff2);
   GetQDGlobalsScreenBits(&src);
+
+  storebg.top = 0;
+  storebg.bottom = 32;
+  storebg.left = 0;
+  storebg.right = 32;
 
   store.top = 0;
   store.bottom = 32;
@@ -267,9 +274,16 @@ void moveicon(void) {
     goto fastmove;
   }
 
-  iconop = iconpict;
   OffsetRect(&iconpict, GlobalLeft, GlobalTop);
 
+  /* Save a pristine copy of the icon (including its white list background) into
+   * gedge. The dragged icon is always drawn from this copy, so it never re-reads
+   * overlapping screen pixels (which used to smear copies of the icon when
+   * dragging near its source) and stays opaque on top of whatever is behind it.
+   * gbuff2 holds the screen pixels currently hidden under the icon so they can
+   * be restored as the icon moves. Each move modifies the screen buffer directly
+   * rather than a window, so nothing presents it automatically; we push the
+   * buffer to the window after each step so the icon is visible while dragging. */
   CopyBits(src, dst, &iconpict, &store, 0, NIL);
   do {
     GetMouse(&point);
@@ -281,20 +295,29 @@ void moveicon(void) {
       iconnp.right = iconnp.left + 32;
 
       OffsetRect(&iconnp, GlobalLeft, GlobalTop);
-      OffsetRect(&iconop, GlobalLeft, GlobalTop);
 
-      CopyBits(dst, src, &store, &iconop, 0, NIL);
-      CopyBits(src, dst, &iconnp, &store, 0, NIL);
-      CopyBits(src, src, &iconpict, &iconnp, 39, NIL);
+      if (haveold) {
+        OffsetRect(&iconop, GlobalLeft, GlobalTop);
+        CopyBits(bgbuf, src, &storebg, &iconop, 0, NIL);
+      }
+
+      CopyBits(src, bgbuf, &iconnp, &storebg, 0, NIL);
+      CopyBits(dst, src, &store, &iconnp, transparent, NIL);
       OffsetRect(&iconnp, -GlobalLeft, -GlobalTop);
 
       iconop = iconnp;
       oldpoint = point;
+      haveold = 1;
+
+      WindowManager_PresentScreen();
     }
   } while (StillDown());
 
-  OffsetRect(&iconop, GlobalLeft, GlobalTop);
-  CopyBits(dst, src, &store, &iconop, 0, NIL);
+  if (haveold) {
+    OffsetRect(&iconop, GlobalLeft, GlobalTop);
+    CopyBits(bgbuf, src, &storebg, &iconop, 0, NIL);
+    WindowManager_PresentScreen();
+  }
   /* *** END CHANGES *** */
 
 fastmove:

--- a/src/realmz_orig/moveicon.c
+++ b/src/realmz_orig/moveicon.c
@@ -27,7 +27,7 @@ void itemcost(short mode) /****** 1 = sell, else buy ****/
 void moveicon(void) {
   float charge1, charge2 = 0;
   short valu, max, tempshop;
-  Rect iconpict, iconnp, iconop, iconstore, store, storebg;
+  Rect iconpict, iconnp, iconop, iconstore, store;
   Point oldpoint;
   Boolean empty = 0;
   Boolean doupdateshop = 0;
@@ -36,8 +36,16 @@ void moveicon(void) {
   short leftvalue, temp;
   struct itemattr tempitem;
   Boolean baditem = 0;
-  Boolean haveold = 0;
   int index;
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(akelsall): storebg is the source rect for gbuff2, which holds the screen
+   * pixels currently hidden under the dragged icon; haveold tracks whether we have
+   * a previous icon position to restore. These support drawing the dragged icon
+   * opaquely without smearing (see the larger comment below).
+   */
+  Rect storebg;
+  Boolean haveold = 0;
+  /* *** END CHANGES *** */
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
    * NOTE(danapplegate): It seems that the global screen buffer was directly accessible. We've
    * updated the implementation here to achieve a similar effect with our in-memory screen buffer.
@@ -276,7 +284,8 @@ void moveicon(void) {
 
   OffsetRect(&iconpict, GlobalLeft, GlobalTop);
 
-  /* Save a pristine copy of the icon (including its white list background) into
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(akelsall): Save a pristine copy of the icon (including its white list background) into
    * gedge. The dragged icon is always drawn from this copy, so it never re-reads
    * overlapping screen pixels (which used to smear copies of the icon when
    * dragging near its source) and stays opaque on top of whatever is behind it.

--- a/src/realmz_orig/moveicon.c
+++ b/src/realmz_orig/moveicon.c
@@ -292,7 +292,8 @@ void moveicon(void) {
    * gbuff2 holds the screen pixels currently hidden under the icon so they can
    * be restored as the icon moves. Each move modifies the screen buffer directly
    * rather than a window, so nothing presents it automatically; we push the
-   * buffer to the window after each step so the icon is visible while dragging. */
+   * buffer to the window after each step so the icon is visible while dragging. 
+   */
   CopyBits(src, dst, &iconpict, &store, 0, NIL);
   do {
     GetMouse(&point);


### PR DESCRIPTION
What this is:
- Restores the original game's visible item dragging in the shop. While buying or selling, the cursor hides and the item icon follows the mouse, matching the 1994 build.
- Previously the dragged icon was written into the in-memory screen buffer but never shown, so the cursor just disappeared with nothing in its place.

How it works:
- Adds a way to present the screen buffer to the window without recompositing the window stack, called as the icon moves. Recompositing would immediately erase the transient icon.
- Draws the icon from a saved pristine copy with a transparent blit, so it stays on top of any background instead of blending with it.
- Saves the pixels hidden under the icon in a separate buffer and restores them cleanly, which stops the icon smearing into duplicates when dragged over its own list slot.
- Clamps ShowCursor to the visible cursor level, as on Classic Mac OS. The game calls ShowCursor far more than HideCursor, which had driven the level negative and left the cursor visible during subsequent drags.

Stays macOS and Windows compatible: the change lives in the SDL screen presentation path and the shared QuickDraw cursor and CopyBits shims, with no platform specific code.

Both MacOS9 and port blend the icon over other colors:
<img width="122" height="105" alt="image" src="https://github.com/user-attachments/assets/45c5f3b0-5377-43b2-ba41-d2d33f2f59c9" />

This is now fixed in this PR too:
<img width="89" height="65" alt="image" src="https://github.com/user-attachments/assets/8ea7e8e0-3cd7-471a-be3c-abd884f19091" />

Dragging morning star from shop:
<img width="795" height="622" alt="image" src="https://github.com/user-attachments/assets/34943aea-f8ee-4e3a-b3d4-141bcc11c8ab" />
