### PR TITLE
Use the Control key as Command on Windows

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -428,11 +428,24 @@ protected:
         this->set_modifier_value(EVMOD_RIGHT_CONTROL_KEY_DOWN, e.key.mod & SDL_KMOD_RCTRL);
         this->set_modifier_value(EVMOD_RIGHT_OPTION_KEY_DOWN, e.key.mod & SDL_KMOD_RALT);
         this->set_modifier_value(EVMOD_RIGHT_SHIFT_KEY_DOWN, e.key.mod & SDL_KMOD_RSHIFT);
+#ifdef _WIN32
+        // On Windows the Control key stands in for the Mac Command key (see the Command mapping
+        // below), so it must not also set the Control bit. Doing both would select the
+        // control-character KCHR table and break Command-key shortcuts and typed characters.
+        this->set_modifier_value(EVMOD_CONTROL_KEY_DOWN, false);
+#else
         this->set_modifier_value(EVMOD_CONTROL_KEY_DOWN, e.key.mod & SDL_KMOD_LCTRL);
+#endif
         this->set_modifier_value(EVMOD_OPTION_KEY_DOWN, e.key.mod & SDL_KMOD_LALT);
         this->set_modifier_value(EVMOD_CAPS_LOCK_ENABLED, e.key.mod & SDL_KMOD_CAPS);
         this->set_modifier_value(EVMOD_SHIFT_KEY_DOWN, e.key.mod & SDL_KMOD_LSHIFT);
+#ifdef _WIN32
+        // The Windows (Super) key is reserved by the OS for the Start menu and shell shortcuts, so
+        // it cannot reliably act as the Mac Command key. Map the Control key to Command instead.
+        this->set_modifier_value(EVMOD_COMMAND_KEY_DOWN, e.key.mod & SDL_KMOD_LCTRL);
+#else
         this->set_modifier_value(EVMOD_COMMAND_KEY_DOWN, e.key.mod & SDL_KMOD_GUI);
+#endif
 
         uint32_t message = mac_message_for_sdl_key_code(e.key.key, this->modifier_flags);
         bool enqueue = true;


### PR DESCRIPTION
Why:
- On Windows the Mac Command modifier was mapped to the Super (Windows) key.
- The OS reserves that key for the Start menu and shell shortcuts, so using it for equipping items, using items in combat, casting spells, and menu shortcuts is awkward (opens start menu).

How:
- On Windows, map the Control key to Command instead of the Super key.
- Leave the Control bit clear while Control is held so the KCHR lookup matches a plain Command press; setting both bits would select the control-character table and break shortcuts and typed input.
- Control was otherwise only a warning-suppress modifier on the shop/item screen, behind the Command check, so there is no collision.
- macOS is unchanged and still uses the Command key.

Refs #152