### PR TITLE
Add Port menu for display settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ set(SOURCES
     src/Font.cpp
     src/MemoryManager.cpp
     src/MenuManager.cpp
+    src/PortPrefs.cpp
     src/QuickDraw.cpp
     src/ResourceManager.cpp
     src/SDLHelpers.cpp

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -413,12 +413,25 @@ protected:
     em_log.debug_f("Enqueued event (what={}, message=0x{:08X}, when=0x{:08X}, where=(h={}, v={}), modifiers=0x{:04X})", name_for_event_type(ev.what), ev.message, ev.when, ev.where.h, ev.where.v, ev.modifiers);
   }
 
-  void enqueue_sdl_event(const SDL_Event& e) {
+  void enqueue_sdl_event(const SDL_Event& e_in) {
+    SDL_Event e = e_in;
+    if (auto* renderer = SDL_GetRenderer(WindowManager::instance().get_sdl_window().get())) {
+      SDL_ConvertEventToRenderCoordinates(renderer, &e);
+    }
     switch (e.type) {
       // TODO: Handle any cleanup of specific window that was closed
       //  case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
       case SDL_EVENT_QUIT:
+        WindowManager::instance().save_prefs();
         exit(EXIT_SUCCESS);
+        break;
+      case SDL_EVENT_WINDOW_RESIZED:
+        WindowManager::instance().snap_aspect();
+        WindowManager::instance().recomposite_all();
+        break;
+      case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+      case SDL_EVENT_WINDOW_EXPOSED:
+        WindowManager::instance().recomposite_all();
         break;
       case SDL_EVENT_KEY_DOWN:
       case SDL_EVENT_KEY_UP: {

--- a/src/MenuController.h
+++ b/src/MenuController.h
@@ -10,6 +10,15 @@ extern "C" {
 void MCSync(std::shared_ptr<MenuList> menuList, void (*callback)(int16_t, int16_t));
 void MCCreatePopupMenu(void* nsWindow, std::shared_ptr<Menu> menu, std::pair<int16_t, int16_t> loc, void (*callback)(int16_t, int16_t));
 
+int WM_GetScaleMode(void);
+void WM_SetScaleMode(int mode);
+void WM_SetWindowSize(int w, int h);
+int WM_SizeFits(int w, int h);
+void WM_GetWindowSize(int* w, int* h);
+int WM_IsFullscreen(void);
+int WM_GetAspectLocked(void);
+void WM_SetAspectLocked(int locked);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/MenuController.h
+++ b/src/MenuController.h
@@ -18,6 +18,8 @@ void WM_GetWindowSize(int* w, int* h);
 int WM_IsFullscreen(void);
 int WM_GetAspectLocked(void);
 void WM_SetAspectLocked(int locked);
+int WM_GetGammaIdx(void);
+void WM_SetGammaIdx(int idx);
 
 #ifdef __cplusplus
 }

--- a/src/PortMenu.hpp
+++ b/src/PortMenu.hpp
@@ -18,9 +18,9 @@ struct PortScaleOption {
 };
 
 inline constexpr PortFilterOption kPortFilters[] = {
-    {"Filter: Pixel Art", SDL_SCALEMODE_PIXELART},
-    {"Filter: Linear", SDL_SCALEMODE_LINEAR},
-    {"Filter: Nearest", SDL_SCALEMODE_NEAREST},
+    {"Pixel Art", SDL_SCALEMODE_PIXELART},
+    {"Linear", SDL_SCALEMODE_LINEAR},
+    {"Nearest", SDL_SCALEMODE_NEAREST},
 };
 
 inline constexpr PortScaleOption kPortScales[] = {

--- a/src/PortMenu.hpp
+++ b/src/PortMenu.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <SDL3/SDL_surface.h>
+
+// Cross-platform definition of the contents of the "Port" menu. The menu UI is
+// built natively on each platform (Cocoa on macOS, the Win32 menu API on
+// Windows), but the option lists live here so both platforms stay in sync.
+
+struct PortFilterOption {
+  const char* title;
+  SDL_ScaleMode mode;
+};
+
+struct PortScaleOption {
+  const char* title;
+  int width;
+  int height;
+};
+
+inline constexpr PortFilterOption kPortFilters[] = {
+    {"Filter: Pixel Art", SDL_SCALEMODE_PIXELART},
+    {"Filter: Linear", SDL_SCALEMODE_LINEAR},
+    {"Filter: Nearest", SDL_SCALEMODE_NEAREST},
+};
+
+inline constexpr PortScaleOption kPortScales[] = {
+    {"1x", 800, 600},
+    {"1.5x", 1200, 900},
+    {"2x", 1600, 1200},
+    {"2.5x", 2000, 1500},
+    {"3x", 2400, 1800},
+};
+
+inline constexpr int kPortFilterCount = sizeof(kPortFilters) / sizeof(kPortFilters[0]);
+inline constexpr int kPortScaleCount = sizeof(kPortScales) / sizeof(kPortScales[0]);

--- a/src/PortMenu.hpp
+++ b/src/PortMenu.hpp
@@ -33,3 +33,21 @@ inline constexpr PortScaleOption kPortScales[] = {
 
 inline constexpr int kPortFilterCount = sizeof(kPortFilters) / sizeof(kPortFilters[0]);
 inline constexpr int kPortScaleCount = sizeof(kPortScales) / sizeof(kPortScales[0]);
+
+// Gamma correction options for the Color Correction submenu.
+// display_gamma = 0 means off (no correction).
+// Otherwise the correction applied is pow(v/255, 1.8/display_gamma) per channel,
+// treating Mac source as 1.8-gamma content and converting to the given display gamma.
+struct PortGammaOption {
+  const char* title;
+  float display_gamma;
+};
+
+inline constexpr PortGammaOption kPortGammaOptions[] = {
+    {"Off",  0.0f},
+    {"2.0",  2.0f},
+    {"2.2",  2.2f},
+    {"2.59", 2.59f},
+};
+
+inline constexpr int kPortGammaCount = sizeof(kPortGammaOptions) / sizeof(kPortGammaOptions[0]);

--- a/src/PortMenu.hpp
+++ b/src/PortMenu.hpp
@@ -47,7 +47,7 @@ inline constexpr PortGammaOption kPortGammaOptions[] = {
     {"Off",  0.0f},
     {"2.0",  2.0f},
     {"2.2",  2.2f},
-    {"2.59", 2.59f},
+    {"2.59 (SheepShaver)", 2.59f},
 };
 
 inline constexpr int kPortGammaCount = sizeof(kPortGammaOptions) / sizeof(kPortGammaOptions[0]);

--- a/src/PortPrefs.cpp
+++ b/src/PortPrefs.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <string>
 
+#include "PortMenu.hpp"
+
 #include <phosg/Filesystem.hh>
 #include <phosg/JSON.hh>
 #include <phosg/Strings.hh>
@@ -70,6 +72,7 @@ PortPrefs load_port_prefs() {
     prefs.window_h = std::clamp(static_cast<int>(root.get_int("window_h", prefs.window_h)), MIN_DIM, MAX_H);
     prefs.scale_mode = scale_mode_for_name(root.get_string("filter", name_for_scale_mode(prefs.scale_mode)));
     prefs.aspect_locked = root.get_bool("aspect_locked", prefs.aspect_locked);
+    prefs.gamma_idx = std::clamp(static_cast<int>(root.get_int("gamma_idx", prefs.gamma_idx)), 0, kPortGammaCount - 1);
   } catch (const std::exception& e) {
     prefs_log.warning_f("Could not parse {} ({}); using defaults", path, e.what());
     return PortPrefs{};
@@ -91,6 +94,7 @@ void save_port_prefs(const PortPrefs& prefs) {
   root.emplace("window_h", static_cast<int64_t>(prefs.window_h));
   root.emplace("filter", name_for_scale_mode(prefs.scale_mode));
   root.emplace("aspect_locked", prefs.aspect_locked);
+  root.emplace("gamma_idx", static_cast<int64_t>(prefs.gamma_idx));
 
   try {
     phosg::save_file(path, root.serialize());

--- a/src/PortPrefs.cpp
+++ b/src/PortPrefs.cpp
@@ -1,0 +1,100 @@
+#include "PortPrefs.hpp"
+
+#include <SDL3/SDL_filesystem.h>
+
+#include <algorithm>
+#include <string>
+
+#include <phosg/Filesystem.hh>
+#include <phosg/JSON.hh>
+#include <phosg/Strings.hh>
+
+#include "Types.hpp"
+
+static phosg::PrefixedLogger prefs_log("[PortPrefs] ", DEFAULT_LOG_LEVEL);
+
+static constexpr int MIN_DIM = 1;
+static constexpr int MAX_W = 800 * 4;
+static constexpr int MAX_H = 600 * 4;
+
+static std::string prefs_path() {
+  char* base = SDL_GetPrefPath("Fantasoft", "Realmz");
+  if (!base) {
+    return std::string();
+  }
+  std::string path = std::string(base) + "port_settings.json";
+  SDL_free(base);
+  return path;
+}
+
+static const char* name_for_scale_mode(SDL_ScaleMode mode) {
+  switch (mode) {
+    case SDL_SCALEMODE_LINEAR:
+      return "linear";
+    case SDL_SCALEMODE_NEAREST:
+      return "nearest";
+    default:
+      return "pixelart";
+  }
+}
+
+static SDL_ScaleMode scale_mode_for_name(const std::string& name) {
+  if (name == "linear") {
+    return SDL_SCALEMODE_LINEAR;
+  } else if (name == "nearest") {
+    return SDL_SCALEMODE_NEAREST;
+  }
+  return SDL_SCALEMODE_PIXELART;
+}
+
+PortPrefs load_port_prefs() {
+  PortPrefs prefs;
+
+  std::string path = prefs_path();
+  if (path.empty()) {
+    prefs_log.warning_f("Could not get pref path: {}; using defaults", SDL_GetError());
+    return prefs;
+  }
+
+  std::string data;
+  try {
+    data = phosg::load_file(path);
+  } catch (const std::exception& e) {
+    prefs_log.info_f("Could not read {} ({}); using defaults", path, e.what());
+    return prefs;
+  }
+
+  try {
+    auto root = phosg::JSON::parse(data);
+    prefs.window_w = std::clamp(static_cast<int>(root.get_int("window_w", prefs.window_w)), MIN_DIM, MAX_W);
+    prefs.window_h = std::clamp(static_cast<int>(root.get_int("window_h", prefs.window_h)), MIN_DIM, MAX_H);
+    prefs.scale_mode = scale_mode_for_name(root.get_string("filter", name_for_scale_mode(prefs.scale_mode)));
+    prefs.aspect_locked = root.get_bool("aspect_locked", prefs.aspect_locked);
+  } catch (const std::exception& e) {
+    prefs_log.warning_f("Could not parse {} ({}); using defaults", path, e.what());
+    return PortPrefs{};
+  }
+
+  prefs_log.info_f("Loaded prefs: window {}x{}, filter {}", prefs.window_w, prefs.window_h, name_for_scale_mode(prefs.scale_mode));
+  return prefs;
+}
+
+void save_port_prefs(const PortPrefs& prefs) {
+  std::string path = prefs_path();
+  if (path.empty()) {
+    prefs_log.warning_f("Could not get pref path: {}; not saving prefs", SDL_GetError());
+    return;
+  }
+
+  phosg::JSON root = phosg::JSON::dict();
+  root.emplace("window_w", static_cast<int64_t>(prefs.window_w));
+  root.emplace("window_h", static_cast<int64_t>(prefs.window_h));
+  root.emplace("filter", name_for_scale_mode(prefs.scale_mode));
+  root.emplace("aspect_locked", prefs.aspect_locked);
+
+  try {
+    phosg::save_file(path, root.serialize());
+  } catch (const std::exception& e) {
+    prefs_log.warning_f("Could not write {} ({})", path, e.what());
+  }
+}

--- a/src/PortPrefs.hpp
+++ b/src/PortPrefs.hpp
@@ -7,6 +7,7 @@ struct PortPrefs {
   int window_h = 600;
   SDL_ScaleMode scale_mode = SDL_SCALEMODE_PIXELART;
   bool aspect_locked = true;
+  int gamma_idx = 0; // index into kPortGammaOptions
 };
 
 PortPrefs load_port_prefs();

--- a/src/PortPrefs.hpp
+++ b/src/PortPrefs.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <SDL3/SDL_surface.h>
+
+struct PortPrefs {
+  int window_w = 800;
+  int window_h = 600;
+  SDL_ScaleMode scale_mode = SDL_SCALEMODE_PIXELART;
+  bool aspect_locked = true;
+};
+
+PortPrefs load_port_prefs();
+void save_port_prefs(const PortPrefs& prefs);

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1,5 +1,7 @@
 #include "WindowManager.hpp"
 
+#include "PortPrefs.hpp"
+
 #include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_properties.h>
 #include <memory>
@@ -938,16 +940,26 @@ WindowManager::~WindowManager() = default;
 void WindowManager::create_sdl_window() {
   wm_log.debug_f("WindowManager::create_sdl_window()");
 
-  static constexpr size_t w = 800;
-  static constexpr size_t h = 600;
-  this->sdl_window = sdl_make_shared(SDL_CreateWindow("Realmz", w, h, 0));
+  static constexpr int logical_w = 800;
+  static constexpr int logical_h = 600;
+
+  PortPrefs prefs = load_port_prefs();
+  this->scale_mode = prefs.scale_mode;
+  this->aspect_locked = prefs.aspect_locked;
+
+  this->sdl_window = sdl_make_shared(SDL_CreateWindow("Realmz", prefs.window_w, prefs.window_h, SDL_WINDOW_RESIZABLE));
   if (!this->sdl_window) {
     throw std::runtime_error(std::format("Could not create SDL window: {}", SDL_GetError()));
   }
-  if (!SDL_CreateRenderer(this->sdl_window.get(), nullptr)) {
+  // 4:3 enforced by snap_aspect() on resize, not SDL_SetWindowAspectRatio (crashes macOS fullscreen exit; SDL #14229, notourbug).
+
+  SDL_Renderer* renderer = SDL_CreateRenderer(this->sdl_window.get(), nullptr);
+  if (!renderer) {
     throw std::runtime_error(std::format("Could not create window renderer: {}", SDL_GetError()));
   }
-  this->screen_port.resize(w, h);
+  SDL_SetRenderLogicalPresentation(renderer, logical_w, logical_h, SDL_LOGICAL_PRESENTATION_LETTERBOX);
+
+  this->screen_port.resize(logical_w, logical_h);
   this->recomposite_all();
 }
 
@@ -1187,6 +1199,9 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
         if (!texture) {
           wm_log.error_f("Could not create texture: {}", SDL_GetError());
         } else {
+          SDL_SetTextureScaleMode(texture.get(), this->scale_mode);
+          SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+          SDL_RenderClear(renderer);
           SDL_RenderTexture(renderer, texture.get(), nullptr, nullptr);
         }
       }
@@ -1226,6 +1241,111 @@ void WindowManager::recomposite_from_window(std::shared_ptr<Window> updated_wind
 }
 void WindowManager::recomposite_all() {
   this->recomposite(nullptr);
+}
+
+void WindowManager::set_scale_mode(SDL_ScaleMode mode) {
+  if (mode == this->scale_mode) {
+    return;
+  }
+  this->scale_mode = mode;
+  this->recomposite_all();
+  this->save_prefs();
+}
+
+void WindowManager::snap_aspect() {
+  if (!this->sdl_window || !this->aspect_locked || this->is_fullscreen()) {
+    return;
+  }
+  int w = 0, h = 0;
+  SDL_GetWindowSize(this->sdl_window.get(), &w, &h);
+  int snapped_h = (w * 600 + 400) / 800;
+  if (snapped_h != h) {
+    SDL_SetWindowSize(this->sdl_window.get(), w, snapped_h);
+  }
+}
+
+void WindowManager::set_aspect_locked(bool locked) {
+  this->aspect_locked = locked;
+  this->snap_aspect();
+  this->save_prefs();
+}
+
+void WindowManager::set_window_size(int w, int h) {
+  if (!this->sdl_window) {
+    return;
+  }
+  SDL_SetWindowSize(this->sdl_window.get(), w, h);
+  this->recomposite_all();
+  this->save_prefs();
+}
+
+bool WindowManager::size_fits(int w, int h) const {
+  if (!this->sdl_window) {
+    return false;
+  }
+  SDL_Rect usable;
+  SDL_DisplayID display = SDL_GetDisplayForWindow(this->sdl_window.get());
+  if (!SDL_GetDisplayUsableBounds(display, &usable)) {
+    return true;
+  }
+  return (w <= usable.w) && (h <= usable.h);
+}
+
+void WindowManager::get_window_size(int* w, int* h) const {
+  if (this->sdl_window) {
+    SDL_GetWindowSize(this->sdl_window.get(), w, h);
+  } else {
+    *w = *h = 0;
+  }
+}
+
+bool WindowManager::is_fullscreen() const {
+  if (!this->sdl_window) {
+    return false;
+  }
+  return (SDL_GetWindowFlags(this->sdl_window.get()) & SDL_WINDOW_FULLSCREEN) != 0;
+}
+
+void WindowManager::save_prefs() const {
+  PortPrefs prefs;
+  prefs.scale_mode = this->scale_mode;
+  prefs.aspect_locked = this->aspect_locked;
+  if (this->sdl_window) {
+    SDL_GetWindowSize(this->sdl_window.get(), &prefs.window_w, &prefs.window_h);
+  }
+  save_port_prefs(prefs);
+}
+
+extern "C" int WM_GetScaleMode(void) {
+  return static_cast<int>(WindowManager::instance().get_scale_mode());
+}
+
+extern "C" void WM_SetScaleMode(int mode) {
+  WindowManager::instance().set_scale_mode(static_cast<SDL_ScaleMode>(mode));
+}
+
+extern "C" void WM_SetWindowSize(int w, int h) {
+  WindowManager::instance().set_window_size(w, h);
+}
+
+extern "C" int WM_SizeFits(int w, int h) {
+  return WindowManager::instance().size_fits(w, h) ? 1 : 0;
+}
+
+extern "C" void WM_GetWindowSize(int* w, int* h) {
+  WindowManager::instance().get_window_size(w, h);
+}
+
+extern "C" int WM_IsFullscreen(void) {
+  return WindowManager::instance().is_fullscreen() ? 1 : 0;
+}
+
+extern "C" int WM_GetAspectLocked(void) {
+  return WindowManager::instance().get_aspect_locked() ? 1 : 0;
+}
+
+extern "C" void WM_SetAspectLocked(int locked) {
+  WindowManager::instance().set_aspect_locked(locked != 0);
 }
 
 void WindowManager::on_debug_signal() {

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1,11 +1,14 @@
 #include "WindowManager.hpp"
 
+#include "PortMenu.hpp"
 #include "PortPrefs.hpp"
 
 #include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_properties.h>
+#include <cmath>
 #include <memory>
 #include <stdexcept>
+#include <vector>
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_events.h>
@@ -946,6 +949,7 @@ void WindowManager::create_sdl_window() {
   PortPrefs prefs = load_port_prefs();
   this->scale_mode = prefs.scale_mode;
   this->aspect_locked = prefs.aspect_locked;
+  this->gamma_idx = prefs.gamma_idx;
 
   this->sdl_window = sdl_make_shared(SDL_CreateWindow("Realmz", prefs.window_w, prefs.window_h, SDL_WINDOW_RESIZABLE));
   if (!this->sdl_window) {
@@ -1190,8 +1194,34 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
         wm_log.info_f("Writing debug{}.bmp", debug_number);
         phosg::save_file(std::format("debug{}.bmp", debug_number++), this->screen_port.data.serialize(phosg::ImageFormat::WINDOWS_BITMAP));
       }
+      // Apply gamma correction if enabled. The correction treats Mac content as
+      // 1.8-gamma-encoded and remaps it for the chosen target display gamma.
+      std::vector<uint32_t> gamma_pixels;
+      const void* surface_data = this->screen_port.data.get_data();
+      float gdisplay = kPortGammaOptions[this->gamma_idx].display_gamma;
+      if (gdisplay > 0.0f) {
+        uint8_t lut[256];
+        float exp = 1.8f / gdisplay;
+        lut[0] = 0;
+        for (int i = 1; i < 255; i++) {
+          lut[i] = static_cast<uint8_t>(std::round(255.0f * std::pow(i / 255.0f, exp)));
+        }
+        lut[255] = 255;
+        size_t n = static_cast<size_t>(w) * h;
+        gamma_pixels.resize(n);
+        const uint32_t* src = static_cast<const uint32_t*>(surface_data);
+        for (size_t i = 0; i < n; i++) {
+          uint32_t p = src[i];
+          gamma_pixels[i] =
+              (static_cast<uint32_t>(lut[(p >> 24) & 0xFF]) << 24) |
+              (static_cast<uint32_t>(lut[(p >> 16) & 0xFF]) << 16) |
+              (static_cast<uint32_t>(lut[(p >>  8) & 0xFF]) <<  8) |
+              (p & 0xFF);
+        }
+        surface_data = gamma_pixels.data();
+      }
       auto surface = sdl_make_unique(SDL_CreateSurfaceFrom(
-          w, h, SDL_PIXELFORMAT_RGBA8888, this->screen_port.data.get_data(), 4 * this->screen_port.data.get_width()));
+          w, h, SDL_PIXELFORMAT_RGBA8888, const_cast<void*>(surface_data), 4 * w));
       if (!surface) {
         wm_log.error_f("Could not create surface: {}", SDL_GetError());
       } else {
@@ -1310,10 +1340,20 @@ void WindowManager::save_prefs() const {
   PortPrefs prefs;
   prefs.scale_mode = this->scale_mode;
   prefs.aspect_locked = this->aspect_locked;
+  prefs.gamma_idx = this->gamma_idx;
   if (this->sdl_window) {
     SDL_GetWindowSize(this->sdl_window.get(), &prefs.window_w, &prefs.window_h);
   }
   save_port_prefs(prefs);
+}
+
+void WindowManager::set_gamma_idx(int idx) {
+  if (idx < 0 || idx >= kPortGammaCount || idx == this->gamma_idx) {
+    return;
+  }
+  this->gamma_idx = idx;
+  this->recomposite_all();
+  this->save_prefs();
 }
 
 extern "C" int WM_GetScaleMode(void) {
@@ -1346,6 +1386,14 @@ extern "C" int WM_GetAspectLocked(void) {
 
 extern "C" void WM_SetAspectLocked(int locked) {
   WindowManager::instance().set_aspect_locked(locked != 0);
+}
+
+extern "C" int WM_GetGammaIdx(void) {
+  return WindowManager::instance().get_gamma_idx();
+}
+
+extern "C" void WM_SetGammaIdx(int idx) {
+  WindowManager::instance().set_gamma_idx(idx);
 }
 
 void WindowManager::on_debug_signal() {

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1195,30 +1195,35 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
         phosg::save_file(std::format("debug{}.bmp", debug_number++), this->screen_port.data.serialize(phosg::ImageFormat::WINDOWS_BITMAP));
       }
       // Apply gamma correction if enabled. The correction treats Mac content as
-      // 1.8-gamma-encoded and remaps it for the chosen target display gamma.
-      std::vector<uint32_t> gamma_pixels;
+      // 1.8-gamma-encoded and remaps it for the chosen target display gamma. The
+      // lookup table is rebuilt only when the gamma option changes, and the pixel
+      // buffer is reused, so an enabled gamma adds only the per-pixel remap (not a
+      // table rebuild and a full-frame allocation) to each present.
       const void* surface_data = this->screen_port.data.get_data();
       float gdisplay = kPortGammaOptions[this->gamma_idx].display_gamma;
       if (gdisplay > 0.0f) {
-        uint8_t lut[256];
-        float exp = 1.8f / gdisplay;
-        lut[0] = 0;
-        for (int i = 1; i < 255; i++) {
-          lut[i] = static_cast<uint8_t>(std::round(255.0f * std::pow(i / 255.0f, exp)));
+        if (this->gamma_lut_idx != this->gamma_idx) {
+          float exp = 1.8f / gdisplay;
+          this->gamma_lut[0] = 0;
+          for (int i = 1; i < 255; i++) {
+            this->gamma_lut[i] = static_cast<uint8_t>(std::round(255.0f * std::pow(i / 255.0f, exp)));
+          }
+          this->gamma_lut[255] = 255;
+          this->gamma_lut_idx = this->gamma_idx;
         }
-        lut[255] = 255;
+        const uint8_t* lut = this->gamma_lut;
         size_t n = static_cast<size_t>(w) * h;
-        gamma_pixels.resize(n);
+        this->gamma_scratch.resize(n);
         const uint32_t* src = static_cast<const uint32_t*>(surface_data);
         for (size_t i = 0; i < n; i++) {
           uint32_t p = src[i];
-          gamma_pixels[i] =
+          this->gamma_scratch[i] =
               (static_cast<uint32_t>(lut[(p >> 24) & 0xFF]) << 24) |
               (static_cast<uint32_t>(lut[(p >> 16) & 0xFF]) << 16) |
               (static_cast<uint32_t>(lut[(p >>  8) & 0xFF]) <<  8) |
               (p & 0xFF);
         }
-        surface_data = gamma_pixels.data();
+        surface_data = this->gamma_scratch.data();
       }
       auto surface = sdl_make_unique(SDL_CreateSurfaceFrom(
           w, h, SDL_PIXELFORMAT_RGBA8888, const_cast<void*>(surface_data), 4 * w));

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -103,6 +103,7 @@ private:
   bool recomposite_enabled = true;
   SDL_ScaleMode scale_mode = SDL_SCALEMODE_PIXELART;
   bool aspect_locked = true;
+  int gamma_idx = 0;
 
   WindowManager();
 
@@ -149,6 +150,9 @@ public:
 
   SDL_ScaleMode get_scale_mode() const { return this->scale_mode; }
   void set_scale_mode(SDL_ScaleMode mode);
+
+  int get_gamma_idx() const { return this->gamma_idx; }
+  void set_gamma_idx(int idx);
 
   void snap_aspect();
   bool get_aspect_locked() const { return this->aspect_locked; }

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -104,6 +104,12 @@ private:
   SDL_ScaleMode scale_mode = SDL_SCALEMODE_PIXELART;
   bool aspect_locked = true;
   int gamma_idx = 0;
+  // Cached gamma correction state, so the present path does not rebuild the LUT
+  // or reallocate the pixel buffer every frame. The LUT is rebuilt only when
+  // gamma_idx changes; the scratch buffer is reused across presents.
+  int gamma_lut_idx = -1;
+  uint8_t gamma_lut[256] = {};
+  std::vector<uint32_t> gamma_scratch;
 
   WindowManager();
 

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -101,6 +101,8 @@ private:
   sdl_window_shared sdl_window;
   bool text_editing_active = false;
   bool recomposite_enabled = true;
+  SDL_ScaleMode scale_mode = SDL_SCALEMODE_PIXELART;
+  bool aspect_locked = true;
 
   WindowManager();
 
@@ -144,6 +146,20 @@ public:
   }
 
   void on_debug_signal();
+
+  SDL_ScaleMode get_scale_mode() const { return this->scale_mode; }
+  void set_scale_mode(SDL_ScaleMode mode);
+
+  void snap_aspect();
+  bool get_aspect_locked() const { return this->aspect_locked; }
+  void set_aspect_locked(bool locked);
+
+  void set_window_size(int w, int h);
+  bool size_fits(int w, int h) const;
+  void get_window_size(int* w, int* h) const;
+  bool is_fullscreen() const;
+
+  void save_prefs() const;
 
 private:
   void print_window_stack() const;

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <objc/NSObject.h>
 #include <phosg/Image.hh>
+#include <SDL3/SDL_surface.h>
 
 NSMenu* MCCreateMenu(const MenuList& menuList);
 NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<std::shared_ptr<Menu>> submenus);
@@ -84,7 +85,7 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
 
 @end
 
-@interface MCMenuBar : NSObject
+@interface MCMenuBar : NSObject <NSMenuDelegate>
 
 @property(readonly) NSMenu* menuObject;
 @property(nonatomic) void (*callback)(int16_t, int16_t);
@@ -108,6 +109,19 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
   callback([identifier menuID], [identifier itemID]);
 }
 
+- (IBAction)MCHandleFilter:(id)sender {
+  WM_SetScaleMode((int)[sender tag]);
+}
+
+- (IBAction)MCHandleScale:(id)sender {
+  NSInteger tag = [sender tag];
+  WM_SetWindowSize((int)(tag >> 16), (int)(tag & 0xFFFF));
+}
+
+- (IBAction)MCHandleAspectLock:(id)sender {
+  WM_SetAspectLocked(!WM_GetAspectLocked());
+}
+
 - (void)MCCreateMenu:(const MenuList&)menuList {
   _menuObject = [[NSMenu alloc] initWithTitle:@"Realmz"];
   [_menuObject setAutoenablesItems:NO];
@@ -120,6 +134,93 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
     if (menu->items.size()) {
       NSMenu* subMenu = [self MCCreateSubMenu:title parentMenu:*menu submenus:menuList.submenus];
       [_menuObject setSubmenu:subMenu forItem:menuItem];
+    }
+  }
+
+  [self addPortMenu];
+}
+
+- (void)addPortMenu {
+  NSMenuItem* portItem = [[NSMenuItem alloc] initWithTitle:@"Port" action:NULL keyEquivalent:@""];
+  [_menuObject addItem:portItem];
+  NSMenu* portMenu = [[NSMenu alloc] initWithTitle:@"Port"];
+  [portMenu setAutoenablesItems:NO];
+  portMenu.delegate = self;
+
+  const struct {
+    const char* title;
+    SDL_ScaleMode mode;
+  } filters[] = {
+      {"Filter: Pixel Art", SDL_SCALEMODE_PIXELART},
+      {"Filter: Linear", SDL_SCALEMODE_LINEAR},
+      {"Filter: Nearest", SDL_SCALEMODE_NEAREST},
+  };
+  for (const auto& f : filters) {
+    NSMenuItem* item = [portMenu addItemWithTitle:[NSString stringWithUTF8String:f.title]
+                                           action:@selector(MCHandleFilter:)
+                                    keyEquivalent:@""];
+    [item setTarget:self];
+    [item setTag:(NSInteger)f.mode];
+  }
+
+  [portMenu addItem:[NSMenuItem separatorItem]];
+  NSMenuItem* scaleItem = [[NSMenuItem alloc] initWithTitle:@"Scale" action:NULL keyEquivalent:@""];
+  [portMenu addItem:scaleItem];
+  NSMenu* scaleMenu = [[NSMenu alloc] initWithTitle:@"Scale"];
+  [scaleMenu setAutoenablesItems:NO];
+  scaleMenu.delegate = self;
+  const struct {
+    const char* title;
+    int w;
+    int h;
+  } scales[] = {
+      {"1x", 800, 600},
+      {"1.5x", 1200, 900},
+      {"2x", 1600, 1200},
+      {"2.5x", 2000, 1500},
+      {"3x", 2400, 1800},
+  };
+  for (const auto& s : scales) {
+    NSMenuItem* item = [scaleMenu addItemWithTitle:[NSString stringWithUTF8String:s.title]
+                                            action:@selector(MCHandleScale:)
+                                     keyEquivalent:@""];
+    [item setTarget:self];
+    [item setTag:(NSInteger)((s.w << 16) | s.h)];
+  }
+  [portMenu setSubmenu:scaleMenu forItem:scaleItem];
+
+  [portMenu addItem:[NSMenuItem separatorItem]];
+  NSMenuItem* aspectItem = [portMenu addItemWithTitle:@"Lock Aspect Ratio"
+                                               action:@selector(MCHandleAspectLock:)
+                                        keyEquivalent:@""];
+  [aspectItem setTarget:self];
+
+  [portMenu addItem:[NSMenuItem separatorItem]];
+  // TODO: Potential color correction.
+  NSMenuItem* gammaItem = [portMenu addItemWithTitle:@"Color Correction"
+                                              action:nil
+                                       keyEquivalent:@""];
+  gammaItem.enabled = NO;
+
+  [_menuObject setSubmenu:portMenu forItem:portItem];
+}
+
+- (void)menuNeedsUpdate:(NSMenu*)menu {
+  int currentMode = WM_GetScaleMode();
+  BOOL fullscreen = WM_IsFullscreen() ? YES : NO;
+  int curW = 0, curH = 0;
+  WM_GetWindowSize(&curW, &curH);
+  for (NSMenuItem* item in menu.itemArray) {
+    if (item.action == @selector(MCHandleFilter:)) {
+      item.state = ((int)item.tag == currentMode) ? NSControlStateValueOn : NSControlStateValueOff;
+    } else if (item.action == @selector(MCHandleScale:)) {
+      int w = (int)(item.tag >> 16);
+      int h = (int)(item.tag & 0xFFFF);
+      item.enabled = (!fullscreen && WM_SizeFits(w, h)) ? YES : NO;
+      item.state = (!fullscreen && curW == w && curH == h) ? NSControlStateValueOn : NSControlStateValueOff;
+    } else if (item.action == @selector(MCHandleAspectLock:)) {
+      item.enabled = !fullscreen;
+      item.state = WM_GetAspectLocked() ? NSControlStateValueOn : NSControlStateValueOff;
     }
   }
 }

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -194,7 +194,6 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
   }
   [portMenu setSubmenu:scaleMenu forItem:scaleItem];
 
-  [portMenu addItem:[NSMenuItem separatorItem]];
   NSMenuItem* aspectItem = [portMenu addItemWithTitle:@"Lock Aspect Ratio"
                                                action:@selector(MCHandleAspectLock:)
                                         keyEquivalent:@""];

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -147,23 +147,28 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
   [portMenu setAutoenablesItems:NO];
   portMenu.delegate = self;
 
+  NSMenuItem* filteringItem = [[NSMenuItem alloc] initWithTitle:@"Filter" action:NULL keyEquivalent:@""];
+  [portMenu addItem:filteringItem];
+  NSMenu* filterMenu = [[NSMenu alloc] initWithTitle:@"Filter"];
+  [filterMenu setAutoenablesItems:NO];
+  filterMenu.delegate = self;
   const struct {
     const char* title;
     SDL_ScaleMode mode;
   } filters[] = {
-      {"Filter: Pixel Art", SDL_SCALEMODE_PIXELART},
-      {"Filter: Linear", SDL_SCALEMODE_LINEAR},
-      {"Filter: Nearest", SDL_SCALEMODE_NEAREST},
+      {"Pixel Art", SDL_SCALEMODE_PIXELART},
+      {"Linear", SDL_SCALEMODE_LINEAR},
+      {"Nearest", SDL_SCALEMODE_NEAREST},
   };
   for (const auto& f : filters) {
-    NSMenuItem* item = [portMenu addItemWithTitle:[NSString stringWithUTF8String:f.title]
-                                           action:@selector(MCHandleFilter:)
-                                    keyEquivalent:@""];
+    NSMenuItem* item = [filterMenu addItemWithTitle:[NSString stringWithUTF8String:f.title]
+                                             action:@selector(MCHandleFilter:)
+                                      keyEquivalent:@""];
     [item setTarget:self];
     [item setTag:(NSInteger)f.mode];
   }
+  [portMenu setSubmenu:filterMenu forItem:filteringItem];
 
-  [portMenu addItem:[NSMenuItem separatorItem]];
   NSMenuItem* scaleItem = [[NSMenuItem alloc] initWithTitle:@"Scale" action:NULL keyEquivalent:@""];
   [portMenu addItem:scaleItem];
   NSMenu* scaleMenu = [[NSMenu alloc] initWithTitle:@"Scale"];

--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -7,6 +7,8 @@
 #include <phosg/Image.hh>
 #include <SDL3/SDL_surface.h>
 
+#include "../PortMenu.hpp"
+
 NSMenu* MCCreateMenu(const MenuList& menuList);
 NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<std::shared_ptr<Menu>> submenus);
 
@@ -122,6 +124,10 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
   WM_SetAspectLocked(!WM_GetAspectLocked());
 }
 
+- (IBAction)MCHandleGamma:(id)sender {
+  WM_SetGammaIdx((int)[sender tag]);
+}
+
 - (void)MCCreateMenu:(const MenuList&)menuList {
   _menuObject = [[NSMenu alloc] initWithTitle:@"Realmz"];
   [_menuObject setAutoenablesItems:NO];
@@ -200,11 +206,19 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
   [aspectItem setTarget:self];
 
   [portMenu addItem:[NSMenuItem separatorItem]];
-  // TODO: Potential color correction.
-  NSMenuItem* gammaItem = [portMenu addItemWithTitle:@"Color Correction"
-                                              action:nil
-                                       keyEquivalent:@""];
-  gammaItem.enabled = NO;
+  NSMenuItem* gammaItem = [[NSMenuItem alloc] initWithTitle:@"Color Correction" action:NULL keyEquivalent:@""];
+  [portMenu addItem:gammaItem];
+  NSMenu* gammaMenu = [[NSMenu alloc] initWithTitle:@"Color Correction"];
+  [gammaMenu setAutoenablesItems:NO];
+  gammaMenu.delegate = self;
+  for (int i = 0; i < kPortGammaCount; i++) {
+    NSMenuItem* item = [gammaMenu addItemWithTitle:[NSString stringWithUTF8String:kPortGammaOptions[i].title]
+                                           action:@selector(MCHandleGamma:)
+                                    keyEquivalent:@""];
+    [item setTarget:self];
+    [item setTag:(NSInteger)i];
+  }
+  [portMenu setSubmenu:gammaMenu forItem:gammaItem];
 
   [_menuObject setSubmenu:portMenu forItem:portItem];
 }
@@ -225,6 +239,8 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
     } else if (item.action == @selector(MCHandleAspectLock:)) {
       item.enabled = !fullscreen;
       item.state = WM_GetAspectLocked() ? NSControlStateValueOn : NSControlStateValueOff;
+    } else if (item.action == @selector(MCHandleGamma:)) {
+      item.state = ((int)item.tag == WM_GetGammaIdx()) ? NSControlStateValueOn : NSControlStateValueOff;
     }
   }
 }

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -20,6 +20,8 @@ void WM_GetWindowSize(int* w, int* h);
 int WM_IsFullscreen(void);
 int WM_GetAspectLocked(void);
 void WM_SetAspectLocked(int locked);
+int WM_GetGammaIdx(void);
+void WM_SetGammaIdx(int idx);
 }
 
 static phosg::PrefixedLogger wmc_log("[WinMenuController] ");
@@ -30,6 +32,7 @@ static phosg::PrefixedLogger wmc_log("[WinMenuController] ");
 static constexpr WORD PORT_FILTER_BASE = 0xE000; // + filter index
 static constexpr WORD PORT_SCALE_BASE = 0xE010; // + scale index
 static constexpr WORD PORT_ASPECT_LOCK = 0xE020;
+static constexpr WORD PORT_GAMMA_BASE = 0xE030; // + gamma index
 static constexpr WORD PORT_CMD_MIN = PORT_FILTER_BASE;
 static constexpr WORD PORT_CMD_MAX = 0xE0FF;
 
@@ -58,9 +61,14 @@ static void BuildPortMenu(HMENU menubar) {
   AppendMenu(port_menu, MF_POPUP, reinterpret_cast<UINT_PTR>(scale_menu), "Scale");
   AppendMenu(port_menu, MF_STRING, PORT_ASPECT_LOCK, "Lock Aspect Ratio");
 
+  HMENU gamma_menu = CreatePopupMenu();
+  WORD gid = PORT_GAMMA_BASE;
+  for (const auto& g : kPortGammaOptions) {
+    AppendMenu(gamma_menu, MF_STRING, gid++, g.title);
+  }
+
   AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);
-  // TODO: Potential color correction.
-  AppendMenu(port_menu, MF_STRING | MF_GRAYED, 0, "Color Correction");
+  AppendMenu(port_menu, MF_POPUP | MF_STRING, reinterpret_cast<UINT_PTR>(gamma_menu), "Color Correction");
 
   AppendMenu(menubar, MF_POPUP | MF_STRING, reinterpret_cast<UINT_PTR>(port_menu), "Port");
 }
@@ -95,6 +103,9 @@ static void UpdatePortMenuState(HMENU menu) {
     } else if (cmd == PORT_ASPECT_LOCK) {
       EnableMenuItem(menu, pos, MF_BYPOSITION | (fullscreen ? MF_GRAYED : MF_ENABLED));
       CheckMenuItem(menu, pos, MF_BYPOSITION | (WM_GetAspectLocked() ? MF_CHECKED : MF_UNCHECKED));
+    } else if ((cmd >= PORT_GAMMA_BASE) && (cmd < PORT_GAMMA_BASE + kPortGammaCount)) {
+      bool on = static_cast<int>(cmd - PORT_GAMMA_BASE) == WM_GetGammaIdx();
+      CheckMenuItem(menu, pos, MF_BYPOSITION | (on ? MF_CHECKED : MF_UNCHECKED));
     }
   }
 }
@@ -108,6 +119,8 @@ static void HandlePortCommand(WORD cmd) {
     WM_SetWindowSize(scale.width, scale.height);
   } else if (cmd == PORT_ASPECT_LOCK) {
     WM_SetAspectLocked(!WM_GetAspectLocked());
+  } else if ((cmd >= PORT_GAMMA_BASE) && (cmd < PORT_GAMMA_BASE + kPortGammaCount)) {
+    WM_SetGammaIdx(static_cast<int>(cmd - PORT_GAMMA_BASE));
   }
 }
 

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -43,12 +43,12 @@ static bool IsPortCommand(WORD cmd) {
 static void BuildPortMenu(HMENU menubar) {
   HMENU port_menu = CreatePopupMenu();
 
+  HMENU filter_menu = CreatePopupMenu();
   WORD id = PORT_FILTER_BASE;
   for (const auto& filter : kPortFilters) {
-    AppendMenu(port_menu, MF_STRING, id++, filter.title);
+    AppendMenu(filter_menu, MF_STRING, id++, filter.title);
   }
-
-  AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);
+  AppendMenu(port_menu, MF_POPUP | MF_STRING, reinterpret_cast<UINT_PTR>(filter_menu), "Filter");
 
   HMENU scale_menu = CreatePopupMenu();
   id = PORT_SCALE_BASE;

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -4,10 +4,114 @@
 #include <memory>
 #include <phosg/Strings.hh>
 
+#include "../PortMenu.hpp"
 #include "./WinMenuController.hpp"
 #include <utility>
 
+// Backend bridge for the Port menu. These are defined in WindowManager.cpp and
+// declared in MenuController.h; they are repeated here so this low-level file can
+// stay free of the heavier MenuManager/ResourceFile headers it otherwise avoids.
+extern "C" {
+int WM_GetScaleMode(void);
+void WM_SetScaleMode(int mode);
+void WM_SetWindowSize(int w, int h);
+int WM_SizeFits(int w, int h);
+void WM_GetWindowSize(int* w, int* h);
+int WM_IsFullscreen(void);
+int WM_GetAspectLocked(void);
+void WM_SetAspectLocked(int locked);
+}
+
 static phosg::PrefixedLogger wmc_log("[WinMenuController] ");
+
+// Command IDs for the Port menu. They sit in a reserved high range so they never
+// collide with the packed (menu_id, item_id) identifiers the game's own menus use,
+// which top out at 0x7F7F because menu_id and item_id are each a single byte.
+static constexpr WORD PORT_FILTER_BASE = 0xE000; // + filter index
+static constexpr WORD PORT_SCALE_BASE = 0xE010; // + scale index
+static constexpr WORD PORT_ASPECT_LOCK = 0xE020;
+static constexpr WORD PORT_CMD_MIN = PORT_FILTER_BASE;
+static constexpr WORD PORT_CMD_MAX = 0xE0FF;
+
+static bool IsPortCommand(WORD cmd) {
+  return (cmd >= PORT_CMD_MIN) && (cmd <= PORT_CMD_MAX);
+}
+
+// Builds the Port menu and appends it to the given menu bar. Mirrors the layout of
+// the macOS Port menu (filters, a Scale submenu, an aspect-lock toggle, and a
+// disabled color-correction placeholder).
+static void BuildPortMenu(HMENU menubar) {
+  HMENU port_menu = CreatePopupMenu();
+
+  WORD id = PORT_FILTER_BASE;
+  for (const auto& filter : kPortFilters) {
+    AppendMenu(port_menu, MF_STRING, id++, filter.title);
+  }
+
+  AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);
+
+  HMENU scale_menu = CreatePopupMenu();
+  id = PORT_SCALE_BASE;
+  for (const auto& scale : kPortScales) {
+    AppendMenu(scale_menu, MF_STRING, id++, scale.title);
+  }
+  AppendMenu(port_menu, MF_POPUP, reinterpret_cast<UINT_PTR>(scale_menu), "Scale");
+
+  AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);
+  AppendMenu(port_menu, MF_STRING, PORT_ASPECT_LOCK, "Lock Aspect Ratio");
+
+  AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);
+  // TODO: Potential color correction.
+  AppendMenu(port_menu, MF_STRING | MF_GRAYED, 0, "Color Correction");
+
+  AppendMenu(menubar, MF_POPUP | MF_STRING, reinterpret_cast<UINT_PTR>(port_menu), "Port");
+}
+
+// Refreshes the checkmarks and enabled state of the Port menu items in the given
+// popup. Called from WM_INITMENUPOPUP so the state is current each time the menu (or
+// its Scale submenu) opens, the same role the menuNeedsUpdate delegate plays on macOS.
+static void UpdatePortMenuState(HMENU menu) {
+  if (!menu) {
+    return;
+  }
+  int current_mode = WM_GetScaleMode();
+  bool fullscreen = WM_IsFullscreen() != 0;
+  int cur_w = 0, cur_h = 0;
+  WM_GetWindowSize(&cur_w, &cur_h);
+
+  int count = GetMenuItemCount(menu);
+  for (int pos = 0; pos < count; pos++) {
+    UINT cmd = GetMenuItemID(menu, pos);
+    if (!IsPortCommand(static_cast<WORD>(cmd))) {
+      continue;
+    }
+    if ((cmd >= PORT_FILTER_BASE) && (cmd < PORT_FILTER_BASE + kPortFilterCount)) {
+      bool on = static_cast<int>(kPortFilters[cmd - PORT_FILTER_BASE].mode) == current_mode;
+      CheckMenuItem(menu, pos, MF_BYPOSITION | (on ? MF_CHECKED : MF_UNCHECKED));
+    } else if ((cmd >= PORT_SCALE_BASE) && (cmd < PORT_SCALE_BASE + kPortScaleCount)) {
+      const auto& scale = kPortScales[cmd - PORT_SCALE_BASE];
+      bool fits = !fullscreen && (WM_SizeFits(scale.width, scale.height) != 0);
+      EnableMenuItem(menu, pos, MF_BYPOSITION | (fits ? MF_ENABLED : MF_GRAYED));
+      bool on = !fullscreen && (cur_w == scale.width) && (cur_h == scale.height);
+      CheckMenuItem(menu, pos, MF_BYPOSITION | (on ? MF_CHECKED : MF_UNCHECKED));
+    } else if (cmd == PORT_ASPECT_LOCK) {
+      EnableMenuItem(menu, pos, MF_BYPOSITION | (fullscreen ? MF_GRAYED : MF_ENABLED));
+      CheckMenuItem(menu, pos, MF_BYPOSITION | (WM_GetAspectLocked() ? MF_CHECKED : MF_UNCHECKED));
+    }
+  }
+}
+
+// Routes a Port menu command to the cross-platform window backend.
+static void HandlePortCommand(WORD cmd) {
+  if ((cmd >= PORT_FILTER_BASE) && (cmd < PORT_FILTER_BASE + kPortFilterCount)) {
+    WM_SetScaleMode(static_cast<int>(kPortFilters[cmd - PORT_FILTER_BASE].mode));
+  } else if ((cmd >= PORT_SCALE_BASE) && (cmd < PORT_SCALE_BASE + kPortScaleCount)) {
+    const auto& scale = kPortScales[cmd - PORT_SCALE_BASE];
+    WM_SetWindowSize(scale.width, scale.height);
+  } else if (cmd == PORT_ASPECT_LOCK) {
+    WM_SetAspectLocked(!WM_GetAspectLocked());
+  }
+}
 
 // Static variable to keep the original window proc
 static WNDPROC g_OldWndProc = nullptr;
@@ -66,7 +170,17 @@ std::pair<int16_t, int16_t> FindMenuItemByKeyEquivalent(char ch) {
 }
 
 LRESULT CALLBACK RealmzWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+  if (msg == WM_INITMENUPOPUP) {
+    UpdatePortMenuState(reinterpret_cast<HMENU>(wParam));
+    return CallWindowProc(g_OldWndProc, hwnd, msg, wParam, lParam);
+  }
+
   if (msg == WM_COMMAND) {
+    WORD cmd = LOWORD(wParam);
+    if (IsPortCommand(cmd)) {
+      HandlePortCommand(cmd);
+      return 0;
+    }
     if (menuCallback != nullptr) {
       auto identifier_pair = UnpackMenuIdentifier(wParam);
       menuCallback(identifier_pair.first, identifier_pair.second);
@@ -120,6 +234,12 @@ void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list,
 
   auto wind_handle = get_window_handle(sdl_window);
 
+  // Capture the current logical size so it can be reapplied after the menu bar is
+  // attached (see the note below). Reapplying the current size rather than a fixed
+  // 800x600 keeps a scale chosen from the Port menu from being reset on the next sync.
+  int client_w = 800, client_h = 600;
+  SDL_GetWindowSize(sdl_window, &client_w, &client_h);
+
   HMENU win_menu = CreateMenu();
   MENUINFO win_menu_info = MENUINFO{
       .cbSize = sizeof(MENUINFO),
@@ -167,6 +287,8 @@ void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list,
     InsertMenuItem(win_menu, menu->menu_id, FALSE, &item_info);
   }
 
+  BuildPortMenu(win_menu);
+
   auto old_menu = GetMenu(wind_handle);
   SetMenu(wind_handle, win_menu);
   HookWndProc(wind_handle);
@@ -181,9 +303,10 @@ void WinMenuSync(SDL_Window* sdl_window, std::shared_ptr<WinMenuList> menu_list,
   // client area of the window, not the full window size inclusive of the menu bar. Since we have to
   // bypass SDL to create the menu directly via the Windows API, it seems that SDL doesn't know that
   // the rendering of the menu bar has shrunk the client area. So, a quick call to SDL_SetWindowSize is
-  // enough to force SDL to realize the menu bar now exists and to expand the window to ensure that the
-  // client area is the full 800x600.
-  SDL_SetWindowSize(sdl_window, 800, 600);
+  // enough to force SDL to realize the menu bar now exists and to expand the window so the client area
+  // is the full size it expects. Reapply the size captured above rather than a fixed 800x600 so a
+  // scale picked from the Port menu survives a menu re-sync.
+  SDL_SetWindowSize(sdl_window, client_w, client_h);
 }
 
 int WinCreatePopupMenu(SDL_Window* sdl_window, std::shared_ptr<WinMenu> menu) {

--- a/src/windows/WinMenuController.cpp
+++ b/src/windows/WinMenuController.cpp
@@ -56,8 +56,6 @@ static void BuildPortMenu(HMENU menubar) {
     AppendMenu(scale_menu, MF_STRING, id++, scale.title);
   }
   AppendMenu(port_menu, MF_POPUP, reinterpret_cast<UINT_PTR>(scale_menu), "Scale");
-
-  AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);
   AppendMenu(port_menu, MF_STRING, PORT_ASPECT_LOCK, "Lock Aspect Ratio");
 
   AppendMenu(port_menu, MF_SEPARATOR, 0, nullptr);


### PR DESCRIPTION
From port-menu branch from @chromancer - adds Windows compatibility and additionally now gamma settings to help match Sheepshaver visually.

Adds a Port menu to the Windows and macOS menu bars with display settings that sit outside the game's own menus.

Filter (Pixel Art / Linear / Nearest) and Scale (1x through 3x) are grouped as submenus. Lock Aspect Ratio is a toggle. Below a separator, Color Correction is a submenu offering Off, 2.0, 2.2, and 2.59 (SheepShaver) gamma options. Each correction treats Mac content as 1.8-gamma-encoded and remaps it for the chosen target display gamma using a per-channel LUT at render time. The 2.59 option matches the empirically measured effective gamma of Mac OS 9 in SheepShaver. Settings persist to port_settings.json in the user's app data directory.

The menu is built natively on each platform - Win32 menu API on Windows, Cocoa on macOS - using a shared option table in PortMenu.hpp so both platforms stay in sync.

<img width="838" height="646" alt="image" src="https://github.com/user-attachments/assets/41dc821d-6f28-4f59-9760-4d22f684ba2a" />

<img width="317" height="130" alt="image" src="https://github.com/user-attachments/assets/e2c1532b-67a6-4278-9e37-119beac986c5" />

<img width="304" height="175" alt="image" src="https://github.com/user-attachments/assets/b0a868e9-09e3-4d63-8d36-c0bfff453fc0" />
