### PR TITLE
Reuse one streaming texture when presenting

### DIFF
--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1178,19 +1178,30 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
         wm_log.info_f("Writing debug{}.bmp", debug_number);
         phosg::save_file(std::format("debug{}.bmp", debug_number++), this->screen_port.data.serialize(phosg::ImageFormat::WINDOWS_BITMAP));
       }
-      // Reuse one streaming texture across frames instead of creating a new
-      // surface and texture every present.
-      if (!this->screen_texture || this->screen_texture_w != w || this->screen_texture_h != h) {
-        this->screen_texture = sdl_make_unique(SDL_CreateTexture(
-            renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, w, h));
-        this->screen_texture_w = w;
-        this->screen_texture_h = h;
+      // Reuse one streaming texture instead of creating a new surface and
+      // texture every present; recreate it on size change or update failure.
+      auto ensure_texture = [&] {
+        if (!this->screen_texture || this->screen_texture_w != w || this->screen_texture_h != h) {
+          this->screen_texture = sdl_make_unique(SDL_CreateTexture(
+              renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, w, h));
+          this->screen_texture_w = w;
+          this->screen_texture_h = h;
+        }
+      };
+      const void* pixels = this->screen_port.data.get_data();
+      ensure_texture();
+      bool updated = this->screen_texture && SDL_UpdateTexture(this->screen_texture.get(), nullptr, pixels, 4 * w);
+      if (!updated) {
+        // The texture can be invalidated, for example by a render device reset;
+        // drop it, recreate, and try once more.
+        this->screen_texture.reset();
+        ensure_texture();
+        updated = this->screen_texture && SDL_UpdateTexture(this->screen_texture.get(), nullptr, pixels, 4 * w);
       }
-      if (!this->screen_texture) {
-        wm_log.error_f("Could not create texture: {}", SDL_GetError());
-      } else {
-        SDL_UpdateTexture(this->screen_texture.get(), nullptr, this->screen_port.data.get_data(), 4 * w);
+      if (updated) {
         SDL_RenderTexture(renderer, this->screen_texture.get(), nullptr, nullptr);
+      } else {
+        wm_log.error_f("Could not update screen texture: {}", SDL_GetError());
       }
 
       SDL_RenderPresent(renderer);

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1172,23 +1172,25 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
       wm_log.error_f("Could not get window renderer: {}", SDL_GetError());
     } else {
 
-      auto w = this->screen_port.data.get_width();
-      auto h = this->screen_port.data.get_height();
+      int w = static_cast<int>(this->screen_port.data.get_width());
+      int h = static_cast<int>(this->screen_port.data.get_height());
       if (ENABLE_RECOMPOSITE_DEBUG) {
         wm_log.info_f("Writing debug{}.bmp", debug_number);
         phosg::save_file(std::format("debug{}.bmp", debug_number++), this->screen_port.data.serialize(phosg::ImageFormat::WINDOWS_BITMAP));
       }
-      auto surface = sdl_make_unique(SDL_CreateSurfaceFrom(
-          w, h, SDL_PIXELFORMAT_RGBA8888, this->screen_port.data.get_data(), 4 * this->screen_port.data.get_width()));
-      if (!surface) {
-        wm_log.error_f("Could not create surface: {}", SDL_GetError());
+      // Reuse one streaming texture across frames instead of creating a new
+      // surface and texture every present.
+      if (!this->screen_texture || this->screen_texture_w != w || this->screen_texture_h != h) {
+        this->screen_texture = sdl_make_unique(SDL_CreateTexture(
+            renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, w, h));
+        this->screen_texture_w = w;
+        this->screen_texture_h = h;
+      }
+      if (!this->screen_texture) {
+        wm_log.error_f("Could not create texture: {}", SDL_GetError());
       } else {
-        auto texture = sdl_make_unique(SDL_CreateTextureFromSurface(renderer, surface.get()));
-        if (!texture) {
-          wm_log.error_f("Could not create texture: {}", SDL_GetError());
-        } else {
-          SDL_RenderTexture(renderer, texture.get(), nullptr, nullptr);
-        }
+        SDL_UpdateTexture(this->screen_texture.get(), nullptr, this->screen_port.data.get_data(), 4 * w);
+        SDL_RenderTexture(renderer, this->screen_texture.get(), nullptr, nullptr);
       }
 
       SDL_RenderPresent(renderer);

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -99,6 +99,10 @@ private:
   std::shared_ptr<Window> top_window;
   std::shared_ptr<Window> bottom_window;
   sdl_window_shared sdl_window;
+  // Reused across presents; declared after sdl_window so it is destroyed first.
+  sdl_texture_ptr screen_texture;
+  int screen_texture_w = 0;
+  int screen_texture_h = 0;
   bool text_editing_active = false;
   bool recomposite_enabled = true;
 


### PR DESCRIPTION
This change came from the performance investigation I did, albeit on the Debug build. This was one of two small things to come out of it. The impact of this on the actual render was only measured to be a few ms on the Release build but figured I'd still put it up to consider/discuss, but happy to decide not to merge this and close if not considered necessary.

## Why
- The compositor created and freed a new SDL surface and GPU texture on every present, so each frame that updated the screen paid a GPU texture allocation and upload it did not need.
- This affected every redraw, including animations.

## How
- Keep one streaming texture, created once and recreated only when the window size changes, and update it in place with SDL_UpdateTexture.
- Recreate the texture if an update fails, so the window recovers after a render device reset.
- Output is unchanged: same pixel format, same full frame upload, same default scale mode.
