### PR TITLE
Clip party roster stat numbers to their boxes

### DIFF
--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -78,6 +78,7 @@ CCGrafPort::CCGrafPort()
   this->bgColor = 0xFFFFFFFF;
   this->rgbFgColor = {0x0000, 0x0000, 0x0000};
   this->rgbBgColor = {0xFFFF, 0xFFFF, 0xFFFF};
+  this->clipRect = {-32767, -32767, 32767, 32767};
   all_ports.emplace(this);
   this->log.debug_f("Created");
 }
@@ -190,7 +191,20 @@ bool CCGrafPort::draw_text_ttf(TTF_Font* font, const std::string& processed_text
     // appears to be off by 1 or 2 pixels sometimes) but it will do for now. There aren't good metrics provided by
     // SDL_ttf for this (ascent/height don't match the actual amount we need to trim) so we have to do this instead.
     size_t y_offset = (img.get_height() > h) ? ((img.get_height() - h) / 2) : 0;
-    data.copy_from_with_blend(img, rect.left, rect.top, w, h, 0, y_offset);
+    // Clip the blit to the port's clip rectangle so glyphs (for example tall
+    // substitute fonts with descenders) can't paint outside the region the
+    // caller intends, which would otherwise leave artifacts that nothing erases.
+    Rect dst = this->clipped_to_port(Rect{
+        .top = rect.top,
+        .left = rect.left,
+        .bottom = static_cast<int16_t>(rect.top + h),
+        .right = static_cast<int16_t>(rect.left + w)});
+    if (dst.right <= dst.left || dst.bottom <= dst.top) {
+      return true;
+    }
+    size_t src_x = dst.left - rect.left;
+    size_t src_y = y_offset + (dst.top - rect.top);
+    data.copy_from_with_blend(img, dst.left, dst.top, dst.right - dst.left, dst.bottom - dst.top, src_x, src_y);
     return true;
   }
 }
@@ -198,7 +212,10 @@ bool CCGrafPort::draw_text_ttf(TTF_Font* font, const std::string& processed_text
 bool CCGrafPort::draw_text_bitmap(const ResourceDASM::BitmapFontRenderer& renderer, const std::string& text, const Rect& rect) {
   uint32_t color32 = rgba8888_for_rgb_color(this->rgbFgColor);
   std::string wrapped_text = renderer.wrap_text_to_pixel_width(text, rect.right - rect.left);
-  renderer.render_text(data, wrapped_text, rect.left, rect.top, rect.right, rect.bottom, color32);
+  // render_text treats the right/bottom arguments as clip bounds, so intersect
+  // them with the port's clip rectangle to keep glyphs inside the region.
+  Rect dst = this->clipped_to_port(rect);
+  renderer.render_text(data, wrapped_text, rect.left, rect.top, dst.right, dst.bottom, color32);
   return true;
 }
 
@@ -1060,6 +1077,16 @@ void ScrollRect(const Rect* r, int16_t dh, int16_t dv, RgnHandle updateRgn) {
       port->copy_from(*port, src_rect, dst_rect, 0);
     }
   }
+}
+
+void ClipRect(const Rect* r) {
+  auto& port = current_port();
+  port.log.debug_f("ClipRect({{x0={}, y0={}, x1={}, y1={}}})", r->left, r->top, r->right, r->bottom);
+  port.clipRect = *r;
+}
+
+void GetClipRect(Rect* r) {
+  *r = current_port().clipRect;
 }
 
 void EraseRect(const Rect* r) {

--- a/src/QuickDraw.h
+++ b/src/QuickDraw.h
@@ -196,6 +196,11 @@ void ScrollRect(const Rect* r, int16_t dh, int16_t dv, RgnHandle updateRgn);
 void EraseRect(const Rect* r);
 void PaintRect(const Rect* r);
 void FrameRect(const Rect* r);
+
+// Constrains subsequent drawing in the current port to the given rectangle.
+// GetClipRect reads back the current clip so callers can save and restore it.
+void ClipRect(const Rect* r);
+void GetClipRect(Rect* r);
 Boolean SectRect(const Rect* src1, const Rect* src2, Rect* dstRect);
 int32_t DeltaPoint(Point ptA, Point ptB);
 void GlobalToLocal(Point* pt);

--- a/src/QuickDraw.hpp
+++ b/src/QuickDraw.hpp
@@ -5,6 +5,7 @@
 #include <SDL3/SDL_pixels.h>
 #include <SDL3_ttf/SDL_ttf.h>
 
+#include <algorithm>
 #include <memory>
 #include <phosg/Image.hh>
 #include <phosg/Strings.hh>
@@ -19,6 +20,10 @@ public:
   phosg::PrefixedLogger log;
   phosg::ImageRGBA8888N data;
   bool is_window;
+  // Rectangular clip region, in the same coordinate space as the drawing calls.
+  // Classic QuickDraw clips drawing to the port's clipRgn; we only need the
+  // rectangular case, so we track a single rect here. Defaults to wide open.
+  Rect clipRect;
 
   static std::unordered_set<const CCGrafPort*> all_ports;
   static CCGrafPort* as_port(void* ptr); // Returns null if ptr is not a CCGrafPort
@@ -45,6 +50,16 @@ public:
     return Point{
         .v = static_cast<int16_t>(p.v - this->portRect.top),
         .h = static_cast<int16_t>(p.h - this->portRect.left),
+    };
+  }
+
+  // Intersects the given rect with the current clip rectangle.
+  inline Rect clipped_to_port(const Rect& r) const {
+    return Rect{
+        .top = std::max(r.top, this->clipRect.top),
+        .left = std::max(r.left, this->clipRect.left),
+        .bottom = std::min(r.bottom, this->clipRect.bottom),
+        .right = std::min(r.right, this->clipRect.right),
     };
   }
 

--- a/src/realmz_orig/updatecharshort.c
+++ b/src/realmz_orig/updatecharshort.c
@@ -5,12 +5,18 @@
 void updatecharshort(short who, short forcebox) {
   GrafPtr oldport;
   short ydist;
+  Rect savedClip;
 
   if ((who < 0) || (who > charnum))
     return;
 
   GetPort(&oldport);
   SetPort(GetWindowPort(screen));
+  // CHANGED FROM ORIGINAL IMPLEMENTATION: clip each stat number to the box it
+  // is erased into. The substitute fonts can be taller than the originals, so
+  // descenders would otherwise paint below the box and leave artifacts that the
+  // per-box EraseRect never clears. Restored before returning.
+  GetClipRect(&savedClip);
   RGBBackColor(&greycolor);
   BackPixPat(base);
   TextFont(font);
@@ -36,6 +42,7 @@ void updatecharshort(short who, short forcebox) {
     MoveTo(600 + leftshift, box.top + 11);
   MyrNumToString(c[who].ac, myString);
   EraseRect(&box);
+  ClipRect(&box);
   MyrDrawCString((Ptr)myString);
 
   box.top = who * 50 + 29;
@@ -51,6 +58,7 @@ void updatecharshort(short who, short forcebox) {
   MyrNumToString(c[who].stamina, myString);
   MoveTo((444 - TextWidth(myString, 0, strlen(myString))) + leftshift, box.top + 12);
   EraseRect(&box);
+  ClipRect(&box);
   if (c[who].stamina < c[who].staminamax)
     ForeColor(whiteColor);
   MyrDrawCString((Ptr)myString);
@@ -68,7 +76,9 @@ void updatecharshort(short who, short forcebox) {
     MyrNumToString(c[who].spellpoints, myString);
     MoveTo((593 - TextWidth(myString, 0, strlen(myString))) + leftshift, box.top + 12);
     EraseRect(&box);
+    ClipRect(&box);
     MyrDrawCString((Ptr)myString);
   }
+  ClipRect(&savedClip);
   SetPort(oldport);
 }


### PR DESCRIPTION
The party roster stat numbers can leave stray pixels below their boxes that never go away.

Why:
- The roster numbers (armor class, stamina, spell points) are drawn in a tall calligraphic font whose glyphs can extend below the short box each number sits in.
- Each refresh only erases that box, so any pixels drawn past it are never cleared and pile up as artifacts.
- The text shim drew glyphs with no clipping, so anything outside the box stayed on screen.

How:
- Add a rectangular clip to the graphics port, honored by both the TrueType and bitmap text paths. It defaults to wide open, so existing drawing is unchanged.
- Add ClipRect and a GetClipRect readback so callers can set the clip and restore the previous one.
- In updatecharshort, clip each number to the same box it is erased into, then restore the prior clip before returning.
- Compatible with both macOS and Windows since it only touches the shared QuickDraw shim and the cross-platform game code.

This was observed with the spell points value label while resting and recovering. The display cycles through values as you rest and leaves artifacts where it's drawn the font below the area that gets repainted.
<img width="292" height="74" alt="image" src="https://github.com/user-attachments/assets/92337207-e203-496d-b56b-ce283a806d0c" />
<img width="174" height="91" alt="image" src="https://github.com/user-attachments/assets/970fa897-c89b-41ec-84b4-8c410bc87d54" />
