### PR TITLE
Fix Open Lock spell chance

### DIFF
--- a/src/realmz_orig/encounters.c
+++ b/src/realmz_orig/encounters.c
@@ -977,7 +977,9 @@ tryagain:
             thief.type[6] = TRUE;
           }
 
-          /*** knock uses sound[1]; sound[2] is disarmtrap ***/
+          /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+           * Open Lock uses thief.sound[1]; thief.sound[2] is Destroy Trap.
+           */
           if (Rand(100) < knockchance) {
             thief.type[9] = FALSE; /*** success ***/
 

--- a/src/realmz_orig/encounters.c
+++ b/src/realmz_orig/encounters.c
@@ -977,7 +977,8 @@ tryagain:
             thief.type[6] = TRUE;
           }
 
-          if (Rand(100) < thief.sound[2] * powerlevel) {
+          /*** knock uses sound[1]; sound[2] is disarmtrap ***/
+          if (Rand(100) < knockchance) {
             thief.type[9] = FALSE; /*** success ***/
 
             sound(thief.sounds[6]);


### PR DESCRIPTION
## Summary

Open Lock encounter spells compute their success chance from `thief.sound[1] * powerlevel`, but the final success roll used `thief.sound[2] * powerlevel` instead. `sound[2]` is used by the Destroy Trap path, so Open Lock could succeed or fail based on the trap-disarm spell chance instead of its own chance.

This changes the Open Lock roll to use the already-computed `knockchance` value.

## Verification

- Inspected the Destroy Trap and Open Lock encounter spell handling in `src/realmz_orig/encounters.c`.
- Ran `git diff --check` locally. It reported only the existing CRLF warning for the touched file.
- Built `Realmz` successfully on Windows with CMake/Ninja using MSYS2 clang.