### PR TITLE
stop two more crashes in party select

### DIFF
--- a/src/realmz_orig/partyselect-helpers.cpp
+++ b/src/realmz_orig/partyselect-helpers.cpp
@@ -32,7 +32,15 @@ extern "C" void update_character_files_list() {
   for (const auto& filename : mac_list_directory(":Character Files")) {
     try {
       auto f = mac_fopen_unique(std::format(":Character Files:{}", filename), "rb");
+      if (!f) {
+        characters_log.info_f("Skipped {} (could not be opened).", filename);
+        continue;
+      }
       auto ch = phosg::freadx<struct character>(f.get());
+      if (!phosg::fread(f.get(), 1).empty()) {
+        characters_log.info_f("Skipped {} (larger than a character record).", filename);
+        continue;
+      }
       CvtCharacterToPc(&ch);
       characters.emplace_back(std::make_pair(filename, ch.level));
     } catch (phosg::io_error const& error) {


### PR DESCRIPTION
there are two more active crashes in party select from my original issue, one I mentioned and one I didn't see until recently.

1. if an oversize (non-character) file exists and is added to party. garbage is parsed as a character and crashes downstream.
2. if a subdirectory exists. mac_fopen returns null for directories (correct behavior for emulating classic). but passing a null FILE* to fread is immediate segfault.

the commit adds two add'l guards for the above.

my principle is that while these result from things that should not happen (there's no intended reason to have directories in Character Files, nor is there any good reason to add a non-character file to your party) we should guard an inexperienced user against crashes by eliding junk files completely and skipping directories