### PR TITLE
Apply weapon magic plus to player melee to-hit

### DIFF
--- a/src/realmz_orig/attack.c
+++ b/src/realmz_orig/attack.c
@@ -69,7 +69,14 @@ short attack(short chare, short mon) {
       }
     }
     damage += item.damage; /******* magic plus ****/
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * The weapon magic plus (item.damage) was added to player melee damage but
+     * never to the to-hit roll. The monster path (attack2) and missile path
+     * (resolvespell) both add 5 per point, and the character sheet attack bonus
+     * already includes it (damage * 5), so player melee was the only path that
+     * ignored it. Add the same term here. */
     att += 5 * item.damage; /******* magic plus to hit; matches attack2 and resolvespell ****/
+    /* *** END CHANGES *** */
     if (item.sp1 == 121)
       att += 5 * item.damage; /******* double to hit weapon ****/
 

--- a/src/realmz_orig/attack.c
+++ b/src/realmz_orig/attack.c
@@ -69,6 +69,7 @@ short attack(short chare, short mon) {
       }
     }
     damage += item.damage; /******* magic plus ****/
+    att += 5 * item.damage; /******* magic plus to hit; matches attack2 and resolvespell ****/
     if (item.sp1 == 121)
       att += 5 * item.damage; /******* double to hit weapon ****/
 


### PR DESCRIPTION
Fixing bug #269.

Player melee attacks ignore a weapon's magic plus when rolling to hit, so a +N weapon does not improve a character's hit chance.

Why:
- `attack()` adds `item.damage` (magic plus) to melee damage but never to the to-hit roll.
- `attack2()` (monster) and `resolvespell()` (missile) both add 5 per point, and the character sheet attack bonus already shows it (`damage * 5`).
- Player melee is the only path that drops it, so the sheet and combat disagree.

How:
- Add `att += 5 * item.damage` in `attack()`, after the damage bonus and before the penetration check, matching attack2/resolvespell.
- Penetration weapons (sp1 == 121) stack the base term with their existing bonus, giving the intended doubling.

Verification:
- Logging from equip and attack code.
- Equip is to see the items stats as it's equipped.
- The top attack of each weapon is the fix toggled off.
- The bottom attack is the fix toggled on.
- Same character, same monster, same weapon. Jitter is to do with luck rating mainly.
- Compare each attacks `att_from_weapon` and `att_final`.

```
Penetration tip sword +2
[EQUIP  ] char=1 item_id=74 plus(item.damage)=2 sp1=121 sp2=0 item.st=0 => c.tohit=20 c.damage=2 c.magst=1 strong=0
[ATTACK ] chare=1 mon=16 weap_id=74 plus=2 sp1=121 fix=0 | char.tohit=23 char.damage=2 strong=0 behind=0 | att_from_weapon=10 att_final=72
[ATTACK ] chare=1 mon=16 weap_id=74 plus=2 sp1=121 fix=1 | char.tohit=23 char.damage=2 strong=0 behind=0 | att_from_weapon=20 att_final=85

war axe of strength +2
[EQUIP  ] char=1 item_id=86 plus(item.damage)=2 sp1=41 sp2=-1 item.st=0 => c.tohit=23 c.damage=2 c.magst=1 strong=0
[ATTACK ] chare=1 mon=17 weap_id=86 plus=2 sp1=41 fix=0 | char.tohit=23 char.damage=2 strong=-1 behind=0 | att_from_weapon=0 att_final=74
[ATTACK ] chare=1 mon=17 weap_id=86 plus=2 sp1=41 fix=1 | char.tohit=23 char.damage=2 strong=-1 behind=0 | att_from_weapon=10 att_final=90

 morningstar +2 - straight +2 weapon
[EQUIP  ] char=1 item_id=60 plus(item.damage)=2 sp1=0 sp2=0 item.st=0 => c.tohit=23 c.damage=2 c.magst=1 strong=0
[ATTACK ] chare=1 mon=17 weap_id=60 plus=2 sp1=0 fix=0 | char.tohit=23 char.damage=2 strong=0 behind=0 | att_from_weapon=0 att_final=61
[ATTACK ] chare=1 mon=17 weap_id=60 plus=2 sp1=0 fix=1 | char.tohit=23 char.damage=2 strong=0 behind=0 | att_from_weapon=10 att_final=69
```