### PR TITLE
Fix fumbled item drops

### DIFF
--- a/src/realmz_orig/attack.c
+++ b/src/realmz_orig/attack.c
@@ -204,13 +204,20 @@ moveon:
 
     if ((templong > 50 && templong < 60) && (c[chare].armor[2])) /**** fumble weapon ****/
     {
-      for (fumloop = 0; fumloop <= c[chare].numitems; fumloop++) {
+      short fumbleditem;
+      /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+       * Guard fumbled item drops against inventory and fumble queue bounds.
+       */
+      for (fumloop = 0; (fumloop < c[chare].numitems) && (fumloop < 30); fumloop++) {
         if (c[chare].items[fumloop].id == c[chare].armor[2]) {
+          if (fumtotal >= 20)
+            goto donefumble;
+          fumbleditem = c[chare].items[fumloop].id;
           if (removeitem(chare, fumloop, FALSE, FALSE)) {
             sound(-10121);
             sound(-10123);
-            fumque[fumtotal++] = c[chare].items[fumloop].id;
-            dropitem(chare, c[chare].items[fumloop].id, fumloop, TRUE, FALSE);
+            fumque[fumtotal++] = fumbleditem;
+            dropitem(chare, fumbleditem, fumloop, TRUE, FALSE);
             c[chare].armor[2] = c[chare].weaponnum = 0;
             warn(114);
             success = FALSE;

--- a/src/realmz_orig/newland.c
+++ b/src/realmz_orig/newland.c
@@ -367,13 +367,20 @@ startover:
           if ((q[up] < 9) && (q[up] > -1)) {
             if (c[charup].armor[2]) /**** fumble weapon ****/
             {
-              for (fumloop = 0; fumloop <= c[charup].numitems; fumloop++) {
+              short fumbleditem;
+              /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+               * Guard fumbled item drops against inventory and fumble queue bounds.
+               */
+              for (fumloop = 0; (fumloop < c[charup].numitems) && (fumloop < 30); fumloop++) {
                 if (c[charup].items[fumloop].id == c[charup].armor[2]) {
+                  if (fumtotal >= 20)
+                    goto donefumble;
+                  fumbleditem = c[charup].items[fumloop].id;
                   if (removeitem(charup, fumloop, FALSE, FALSE)) {
                     sound(-10121);
                     sound(-10123);
-                    fumque[fumtotal++] = c[charup].items[fumloop].id;
-                    dropitem(charup, c[charup].items[fumloop].id, fumloop, TRUE, FALSE);
+                    fumque[fumtotal++] = fumbleditem;
+                    dropitem(charup, fumbleditem, fumloop, TRUE, FALSE);
                     c[charup].armor[2] = c[charup].weaponnum = 0;
                     combatupdate2(charup);
                     goto donefumble;

--- a/src/realmz_orig/spelllist.c
+++ b/src/realmz_orig/spelllist.c
@@ -54,16 +54,23 @@ short spelllist(short who, short special) {
     {
       if (who < 9) {
         if ((c[who].armor[2]) || (c[who].armor[15])) {
+          short fumbleditem;
           temp = c[who].armor[2];
           if (!temp)
             temp = c[who].armor[15];
-          for (fumloop = 0; fumloop <= c[who].numitems; fumloop++) {
+          /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+           * Guard fumbled item drops against inventory and fumble queue bounds.
+           */
+          for (fumloop = 0; (fumloop < c[who].numitems) && (fumloop < 30); fumloop++) {
             if (c[who].items[fumloop].id == temp) {
+              if (fumtotal >= 20)
+                goto donefumble;
+              fumbleditem = c[who].items[fumloop].id;
               if (removeitem(who, fumloop, FALSE, FALSE)) {
                 sound(-10121);
                 sound(-10123);
-                fumque[fumtotal++] = c[who].items[fumloop].id;
-                dropitem(who, c[who].items[fumloop].id, fumloop, TRUE, TRUE);
+                fumque[fumtotal++] = fumbleditem;
+                dropitem(who, fumbleditem, fumloop, TRUE, TRUE);
                 c[who].armor[2] = c[who].weaponnum = 0;
                 goto donefumble;
               }


### PR DESCRIPTION
Fixes #254.

Some player fumble paths scan inventory with `fumloop <= numitems`, which can look one slot past the active inventory. They also append to `fumque[20]` without checking whether the fumble queue is already full.

This tightens the three player item fumble paths:

- weapon fumble during attacks
- encounter opcode 122
- spell special 67 (may not be used by scenarios but uncertain)

The scan now stays within the active inventory and the 30-slot inventory limit, and the fumble queue is checked before adding another item. The matched item id is saved before the unequip/drop sequence so the queued and dropped item stay explicit.