### PR TITLE
Apply worn item magic plus to player melee to-hit

### DIFF
--- a/src/realmz_orig/attack.c
+++ b/src/realmz_orig/attack.c
@@ -69,14 +69,6 @@ short attack(short chare, short mon) {
       }
     }
     damage += item.damage; /******* magic plus ****/
-    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-     * The weapon magic plus (item.damage) was added to player melee damage but
-     * never to the to-hit roll. The monster path (attack2) and missile path
-     * (resolvespell) both add 5 per point, and the character sheet attack bonus
-     * already includes it (damage * 5), so player melee was the only path that
-     * ignored it. Add the same term here. */
-    att += 5 * item.damage; /******* magic plus to hit; matches attack2 and resolvespell ****/
-    /* *** END CHANGES *** */
     if (item.sp1 == 121)
       att += 5 * item.damage; /******* double to hit weapon ****/
 
@@ -102,6 +94,19 @@ short attack(short chare, short mon) {
 
 moveon:
   att += (50 + character.tohit + 20 * behind);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * Every worn item/armor magic plus is summed into character.damage by wear, and
+   * that total already raises the damage dealt (damage += character.damage below)
+   * and the displayed attack bonus (character.damage * 5 in updatecharinfo), but it
+   * never reached the to-hit roll. The weapon path (attack2) and missile path
+   * (resolvespell) add 5 per point for the weapon, and the character sheet adds 5
+   * per point for every worn item, so player melee to-hit was the only place an
+   * item plus was ignored. Add 5 per point of character.damage here so a +N helm or
+   * armor contributes to to-hit, not just a +N weapon. character.damage already
+   * includes the weapon's plus, so this covers it too; the penetration weapon still
+   * adds an extra 5 * item.damage above for its intended doubling. */
+  att += 5 * character.damage;
+  /* *** END CHANGES *** */
   if (character.condition[COND_TANGLED])
     att -= abs(character.condition[COND_TANGLED]); /*** tangled ***/
   if (character.condition[COND_STRONG])


### PR DESCRIPTION
A worn item or armor magic plus, such as a Helm of Might +2, advertises a to-hit bonus on its label but never affected the player melee to-hit roll.

Why:
- attack() only added the weapon's magic plus (5 per point) to the to-hit roll (previous fix in #268)
- Every worn item plus is summed into character.damage by wear, and that total already raised the damage dealt and the displayed attack bonus (character.damage * 5 on the character sheet), but it never reached the to-hit roll.
- So a +N helm or armor showed a to-hit bonus on its label and in the attack bonus, yet contributed nothing when rolling to hit; only the weapon's plus and strength items did.

How:
- Base the to-hit term on character.damage instead of the weapon's item.damage, in the shared moveon path after the base tohit term.
- character.damage already includes the weapon's plus, so this one term covers the weapon and every other worn item, matching the attack bonus on the character sheet and the damage path.
- The penetration weapon (sp1 == 121) still adds an extra 5 * item.damage for its intended doubling.
- Since character.damage applies whether or not a weapon is equipped, an unarmed attacker now also gets the item plus on to-hit, consistent with the damage path and the displayed bonus.
- Change is in the shared original game logic, so it stays macOS and Windows compatible.

Follows on from the weapon-only fix in #268 (issue #269). Provides the item half discussed in #274.