### PR TITLE
Fix class 6 spells like Cosmic Blast always being resisted

### DIFF
--- a/src/realmz_orig/resist.c
+++ b/src/realmz_orig/resist.c
@@ -46,10 +46,17 @@ short resist(short who) {
     }
   }
 
-  if ((who > 9) && (spellinfo.spellclass < 7)) {
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * spellimmune has six entries (classes 0-5), but this guard used "< 7", which
+   * let a class 6 spell (Cosmic Blast) index spellimmune[6], one past the array.
+   * The field that follows in memory is the byte-swapped money[0], so any monster
+   * carrying gold read as immune and always resisted. resolvespell.c already uses
+   * the correct "< 6" guard for the same spellimmune lookup; match it here. */
+  if ((who > 9) && (spellinfo.spellclass < 6)) {
     if ((monster[who - 10].spellimmune[spellinfo.spellclass]) || (monster[who - 10].magres > 100))
       return (TRUE);
   }
+  /* *** END CHANGES *** */
 
   if (((spellinfo.cannot == 1) || (spellinfo.cannot > 2)) && (spellinfo.spellclass != 9) && (spellinfo.spellclass != -9))
     return (FALSE);


### PR DESCRIPTION
Class 6 attack spells like Cosmic Blast are resisted by certain monsters.

Why:
- resist() guards the monster spellimmune lookup with spellclass < 7, but spellimmune only has six entries (classes 0 to 5).
- Cosmic Blast is spellclass 6, so the lookup reads spellimmune[6], one element past the array.
- The field stored right after spellimmune is money[0], so the stray byte is one byte of the monster's gold value, and any nonzero byte reads as immune.
- The out-of-bounds read was in the original 1994 game too, but it was almost always harmless there. On the big-endian Mac the stray byte was the high byte of money[0], so it was nonzero only when a monster carried 256 or more gold, which is rare.
- The modern little-endian port reverses this. CvtMonsterToPc byte-swaps money to little-endian, so the stray byte is now the low byte of the gold value, which is nonzero for almost any monster carrying gold. A long-standing latent bug therefore became a frequent one.
- The net effect on the port is that any monster carrying gold whose low byte is nonzero reads as immune and resists every time, regardless of its real magic resistance.

How:
- Change the guard to spellclass < 6 so class 6 spells skip the out-of-bounds immunity read and fall through to the normal magic resistance roll.
- This matches resolvespell.c, which already guards the same spellimmune lookup with spellclass < 6.
- Touches only shared game logic, so it stays macOS and Windows compatible.
