### PR TITLE
Fix combat crash from out-of-range body id in centerfield

### DIFF
--- a/src/realmz_orig/centerfield.c
+++ b/src/realmz_orig/centerfield.c
@@ -82,8 +82,19 @@ void centerfield(short x, short y) {
         CopyBits(src, dst, &itemRect, &icon, 0, NIL);
 
       } else if (tempicon > -1) {
-        bodyground(tempicon, 1);
-        bq[tempicon] = TRUE;
+        /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+         * Bound the body id before using it to index bq and the body arrays.
+         * bq is char[maxloop] and only body ids 0..maxloop-1 are valid (party
+         * 0..8, monsters 10..10+maxmon-1). A stray field cell holding maxloop
+         * or more made bq[tempicon] = TRUE write past the end of bq on the
+         * stack, corrupting a saved register and crashing later in the same
+         * combat turn. The redraw loop below already bounds its index with
+         * t < maxloop; match it here so an out-of-range id is skipped. */
+        if (tempicon < maxloop) {
+          bodyground(tempicon, 1);
+          bq[tempicon] = TRUE;
+        }
+        /* *** END CHANGES *** */
       }
     }
   }

--- a/src/realmz_orig/centerfield.c
+++ b/src/realmz_orig/centerfield.c
@@ -32,16 +32,10 @@ void centerfield(short x, short y) {
   if (newx > 75)
     x -= (newx - 75);
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-   * Clamp fieldy at 77 rather than 76 so the last row of the field can be
-   * scrolled into view. The look window shows 15 columns by 13 rows, so the
-   * bottom visible row is fieldy + 12; stopping fieldy at 76 left row 89
-   * unreachable while the fieldx clamp of 75 already allowed column 89.
-   * centerpict clamps at 75 and 77 for the same window, which is the pattern
-   * followed here. The redraw loop below bounds its indices to the field, so
-   * the extra row it scans past the window stays in range. */
+   * Clamp fieldy at 77, not 76, so the last field row can scroll into view,
+   * matching the fieldx clamp of 75 and centerpict's 75/77. */
   if (newy > 77)
     y -= (newy - 77);
-  /* *** END CHANGES *** */
 
   fieldx += (x - 7);
   fieldy += (y - 6);
@@ -65,16 +59,10 @@ void centerfield(short x, short y) {
   BackColor(whiteColor);
 
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-   * Stop both loops at the edge of the field. They scan 16 columns by 14 rows
-   * starting at fieldx, fieldy, one more than the 15 by 13 the look window can
-   * show, so the last column and row are drawn outside lookrect and never
-   * reach the screen. With fieldx at its clamp of 75 the column loop ran to
-   * t == 90, and field is short[90][90], so field[90][tt] read past the end of
-   * the array into the globals that follow it. Whatever was there became
-   * tempicon, and any value from 0 to 999 was then treated as a body id: an
-   * in-range field cell only ever holds terrain (1000 and up) or a real body
-   * id (0 to maxloop-1), never anything between. That is where the stray id
-   * came from that made bq[tempicon] = TRUE overwrite the stack. */
+   * Bound both loops to the field (short[90][90]). At the fieldx clamp of 75
+   * the column loop reached field[90][tt], reading past the array into the
+   * globals beyond it; a stray value there became a bad body id that later
+   * smashed the stack at bq[tempicon]. */
   for (tt = fieldy; (tt < fieldy + 14) && (tt < 90); tt++) // Myriad (+11)
   {
     icon.top += 32;
@@ -103,13 +91,7 @@ void centerfield(short x, short y) {
 
       } else if (tempicon > -1) {
         /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-         * Bound the body id before using it to index bq and the body arrays.
-         * bq is char[maxloop] and only body ids 0..maxloop-1 are valid (party
-         * 0..8, monsters 10..10+maxmon-1), so any larger id writes past the end
-         * of bq on the stack. Bounding the loops above stops the field read
-         * that produced such an id, and the redraw loop below already bounds
-         * its index with t < maxloop; keep the write to bq in range too, since
-         * a bad id from any other source would smash the stack here. */
+         * Keep the body id in range for bq (char[maxloop]) before indexing. */
         if (tempicon < maxloop) {
           bodyground(tempicon, 1);
           bq[tempicon] = TRUE;

--- a/src/realmz_orig/centerfield.c
+++ b/src/realmz_orig/centerfield.c
@@ -31,8 +31,17 @@ void centerfield(short x, short y) {
 
   if (newx > 75)
     x -= (newx - 75);
-  if (newy > 76)
-    y -= (newy - 76);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * Clamp fieldy at 77 rather than 76 so the last row of the field can be
+   * scrolled into view. The look window shows 15 columns by 13 rows, so the
+   * bottom visible row is fieldy + 12; stopping fieldy at 76 left row 89
+   * unreachable while the fieldx clamp of 75 already allowed column 89.
+   * centerpict clamps at 75 and 77 for the same window, which is the pattern
+   * followed here. The redraw loop below bounds its indices to the field, so
+   * the extra row it scans past the window stays in range. */
+  if (newy > 77)
+    y -= (newy - 77);
+  /* *** END CHANGES *** */
 
   fieldx += (x - 7);
   fieldy += (y - 6);
@@ -55,13 +64,24 @@ void centerfield(short x, short y) {
   ForeColor(blackColor);
   BackColor(whiteColor);
 
-  for (tt = fieldy; tt < fieldy + 14; tt++) // Myriad (+11)
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * Stop both loops at the edge of the field. They scan 16 columns by 14 rows
+   * starting at fieldx, fieldy, one more than the 15 by 13 the look window can
+   * show, so the last column and row are drawn outside lookrect and never
+   * reach the screen. With fieldx at its clamp of 75 the column loop ran to
+   * t == 90, and field is short[90][90], so field[90][tt] read past the end of
+   * the array into the globals that follow it. Whatever was there became
+   * tempicon, and any value from 0 to 999 was then treated as a body id: an
+   * in-range field cell only ever holds terrain (1000 and up) or a real body
+   * id (0 to maxloop-1), never anything between. That is where the stray id
+   * came from that made bq[tempicon] = TRUE overwrite the stack. */
+  for (tt = fieldy; (tt < fieldy + 14) && (tt < 90); tt++) // Myriad (+11)
   {
     icon.top += 32;
     icon.bottom += 32;
     icon.left = -32;
     icon.right = 0;
-    for (t = fieldx; t < fieldx + 16; t++) // Myriad (+11)
+    for (t = fieldx; (t < fieldx + 16) && (t < 90); t++) // Myriad (+11)
     {
       icon.left += 32;
       icon.right += 32;
@@ -85,11 +105,11 @@ void centerfield(short x, short y) {
         /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
          * Bound the body id before using it to index bq and the body arrays.
          * bq is char[maxloop] and only body ids 0..maxloop-1 are valid (party
-         * 0..8, monsters 10..10+maxmon-1). A stray field cell holding maxloop
-         * or more made bq[tempicon] = TRUE write past the end of bq on the
-         * stack, corrupting a saved register and crashing later in the same
-         * combat turn. The redraw loop below already bounds its index with
-         * t < maxloop; match it here so an out-of-range id is skipped. */
+         * 0..8, monsters 10..10+maxmon-1), so any larger id writes past the end
+         * of bq on the stack. Bounding the loops above stops the field read
+         * that produced such an id, and the redraw loop below already bounds
+         * its index with t < maxloop; keep the write to bq in range too, since
+         * a bad id from any other source would smash the stack here. */
         if (tempicon < maxloop) {
           bodyground(tempicon, 1);
           bq[tempicon] = TRUE;


### PR DESCRIPTION
Starting a combat encounter can crash the game with an access violation partway through the turn.

Why:
- `centerfield` scans 16 columns by 14 rows of `field` starting at `fieldx`, `fieldy`, one more of each than the 15 by 13 the look window shows, so the last column and row are drawn outside `lookrect` and never reach the screen.
- `field` is `short[90][90]`, but the clamp lets `fieldx` reach 75, so the column loop runs to `t == 90` and `field[90][tt]` reads past the end of the array into the globals declared after it.
- Whatever sits there becomes `tempicon`, and any value from 0 to 999 is taken for a body id, since an in-range cell only ever holds terrain (1000 and up) or a real body id.
- That stray id makes `bq[tempicon] = TRUE` write past the end of `bq`, a `char[maxloop]` array on the stack, and overwrite a saved register. The corruption is silent until later in the same turn, when `getup` dereferences the now-bad pointer and the game faults.
- Separately, the `fieldy` clamp of 76 leaves field row 89 unreachable. The bottom visible row is `fieldy + 12`, while the `fieldx` clamp of 75 already allows column 89. `centerpict` clamps at 75 and 77 for the same window.
- This is in the original game logic (`src/realmz_orig/`), not the shim, and not a Mac-versus-Windows difference. The same out-of-bounds read and write exist on every target, and it faults on Windows because of where that toolchain puts the stray byte.

How:
- Bound both scan loops to the field (`t < 90`, `tt < 90`), so the off-screen column and row can no longer read past the array. Nothing visible is lost, since that column and row fall outside `lookrect`.
- Clamp `fieldy` at 77 rather than 76, matching `centerpict`, so the last row of the field can be scrolled into view.
- Keep a bound on the write to `bq`. It is no longer reachable from the field read, but `bq` is a stack array and a bad id from any other source would smash the stack there.
- The change is in shared original code, so it applies to both macOS and Windows.
