### PR TITLE
Draw dBoxProc dialog frames

### DIFF
--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -56,6 +56,73 @@ inline Rect copy_rect(const ResourceDASM::Rect& src) {
   return Rect{.top = src.y1.load(), .left = src.x1.load(), .bottom = src.y2.load(), .right = src.x2.load()};
 }
 
+static void draw_dbox_frame_line(
+    CCGrafPort& port,
+    const Rect& content_rect,
+    int16_t offset,
+    uint32_t top_left_color,
+    uint32_t bottom_right_color) {
+  int32_t left = content_rect.left - offset;
+  int32_t top = content_rect.top - offset;
+  int32_t right = content_rect.right + offset - 1;
+  int32_t bottom = content_rect.bottom + offset - 1;
+
+  port.data.draw_horizontal_line(left, right, top, 0, top_left_color);
+  port.data.draw_vertical_line(left, top, bottom, 0, top_left_color);
+  port.data.draw_horizontal_line(left, right, bottom, 0, bottom_right_color);
+  port.data.draw_vertical_line(right, top, bottom, 0, bottom_right_color);
+}
+
+static void draw_dbox_frame(CCGrafPort& port, const Rect& content_rect) {
+  constexpr int16_t frame_offset = 6;
+  constexpr int16_t edge_offset = frame_offset - 1;
+  constexpr int16_t shadow_trim = 2;
+
+  // Draw Classic Mac dBoxProc chrome outside the dialog content rect.
+  draw_dbox_frame_line(port, content_rect, frame_offset, 0x000000FF, 0x000000FF);
+  port.data.draw_horizontal_line(
+      content_rect.left - edge_offset,
+      content_rect.right + edge_offset - 1,
+      content_rect.top - edge_offset,
+      0,
+      0xBBBBBBFF);
+  port.data.draw_vertical_line(
+      content_rect.left - edge_offset,
+      content_rect.top - edge_offset,
+      content_rect.bottom + edge_offset - 1,
+      0,
+      0xBBBBBBFF);
+  port.data.draw_horizontal_line(
+      content_rect.left - frame_offset + shadow_trim,
+      content_rect.right + edge_offset - 1,
+      content_rect.bottom + edge_offset - 1,
+      0,
+      0x555555FF);
+  port.data.draw_vertical_line(
+      content_rect.right + edge_offset - 1,
+      content_rect.top - frame_offset + shadow_trim,
+      content_rect.bottom + edge_offset - 1,
+      0,
+      0x555555FF);
+  draw_dbox_frame_line(port, content_rect, 4, 0xFFFFFFFF, 0x999999FF);
+  draw_dbox_frame_line(port, content_rect, 3, 0x777777FF, 0x777777FF);
+  draw_dbox_frame_line(port, content_rect, 2, 0x777777FF, 0x777777FF);
+  draw_dbox_frame_line(port, content_rect, 1, 0x777777FF, 0x777777FF);
+
+  port.data.draw_horizontal_line(
+      content_rect.left - frame_offset + shadow_trim,
+      content_rect.right + frame_offset,
+      content_rect.bottom + frame_offset,
+      0,
+      0x000000FF);
+  port.data.draw_vertical_line(
+      content_rect.right + frame_offset,
+      content_rect.top - frame_offset + shadow_trim,
+      content_rect.bottom + frame_offset,
+      0,
+      0x000000FF);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -926,12 +993,12 @@ Window::Window(
       focused_item{nullptr} {
   port.rgbBgColor = background_color;
 
-  // All windows created by Realmz should be borderless, except the first one
-  bool is_borderless = ((this->window_kind == dBoxProc) ||
+  // Warn if a resource asks for Toolbox chrome that this port does not model.
+  bool is_supported_proc_id = ((this->window_kind == dBoxProc) ||
       (this->window_kind == plainDBox) ||
       (this->window_kind == altDBoxProc));
-  if (!is_borderless) {
-    phosg::fwrite_fmt(stderr, "Warning: Creating non-borderless window\n");
+  if (!is_supported_proc_id) {
+    phosg::fwrite_fmt(stderr, "Warning: Creating unsupported window kind {}\n", this->window_kind);
   }
 
   for (auto di : this->dialog_items) {
@@ -1354,11 +1421,15 @@ void WindowManager::recomposite(std::shared_ptr<Window> updated_window) {
   }
 
   for (; window; window = window->window_above) {
-    // Draw window border
-    this->screen_port.data.draw_horizontal_line(window->port.portRect.left - 1, window->port.portRect.right, window->port.portRect.top - 1, 0, 0x000000FF);
-    this->screen_port.data.draw_horizontal_line(window->port.portRect.left - 1, window->port.portRect.right, window->port.portRect.bottom, 0, 0x000000FF);
-    this->screen_port.data.draw_vertical_line(window->port.portRect.left - 1, window->port.portRect.top, window->port.portRect.bottom, 0, 0x000000FF);
-    this->screen_port.data.draw_vertical_line(window->port.portRect.right, window->port.portRect.top, window->port.portRect.bottom, 0, 0x000000FF);
+    if (window->is_dialog_flag && window->window_kind == dBoxProc) {
+      draw_dbox_frame(this->screen_port, window->port.portRect);
+    } else {
+      // Draw window border
+      this->screen_port.data.draw_horizontal_line(window->port.portRect.left - 1, window->port.portRect.right, window->port.portRect.top - 1, 0, 0x000000FF);
+      this->screen_port.data.draw_horizontal_line(window->port.portRect.left - 1, window->port.portRect.right, window->port.portRect.bottom, 0, 0x000000FF);
+      this->screen_port.data.draw_vertical_line(window->port.portRect.left - 1, window->port.portRect.top, window->port.portRect.bottom, 0, 0x000000FF);
+      this->screen_port.data.draw_vertical_line(window->port.portRect.right, window->port.portRect.top, window->port.portRect.bottom, 0, 0x000000FF);
+    }
 
     if (enable_translucent_window_debug) {
       this->screen_port.data.copy_from_with_custom(
@@ -1771,7 +1842,8 @@ WindowPtr WindowManager_CreateNewWindow(int16_t res_id, bool is_dialog, WindowPt
     ref_con = wind.ref_con;
   }
 
-  // If there's a corresponding dctb or wctb, use it to initialize the port's background color. It seems none of the other fields are relevant: they're used for drawing the window frame, but Realmz only uses borderless windows.
+  // If there's a corresponding dctb or wctb, use it to initialize the port's background color.
+  // The other color-table fields describe Toolbox frame chrome; WindowManager draws that separately.
   RGBColor background_color = {0xFFFF, 0xFFFF, 0xFFFF};
   try {
     auto clut_data = GetResource(is_dialog ? ResourceDASM::RESOURCE_TYPE_dctb : ResourceDASM::RESOURCE_TYPE_wctb, res_id);


### PR DESCRIPTION
Fixes #278.

Windows was rendering `dBoxProc` dialogs with only a one-pixel border, so dialogs such as the monster attack table were missing the Classic Mac frame implied by their resource proc ID.

This draws the frame outside the existing dialog content rect during window recomposition. It uses each dialog's `portRect`, so it is not tied to a particular dialog size and does not resize the dialog or move any DITL items. Dialogs using other window kinds are unchanged.

I also updated the old warning text so it describes unsupported window kinds instead of treating every recognized dialog kind as borderless.

Current Windows build:
<img width="1083" height="578" alt="Current Windows dialog without dBoxProc frame" src="https://github.com/user-attachments/assets/224eba86-1336-48c0-bc2a-2ad6f53a1025" />

Classic Mac:
<img width="1155" height="651" alt="Classic Mac dBoxProc frame" src="https://github.com/user-attachments/assets/42bd7822-d2b3-43d8-a486-85e0c3dda960" />

Updated Windows build:
<img width="1146" height="647" alt="Updated Windows dBoxProc frame" src="https://github.com/user-attachments/assets/962edf83-8e33-42d0-93a8-841a78e64c74" />

Edit: I recognize that this is fixing something that's less about Realmz and more about how some of us remember it looking. So if we'd rather just close this one out and work on more important things, I'm good with that.