### PR TITLE
Support legacy scenario resource sidecars

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -3,6 +3,9 @@
 #include <filesystem>
 #include <memory>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdexcept>
+#include <string>
 
 #include "FileManager.hpp"
 #include "MemoryManager.hpp"
@@ -22,6 +25,57 @@
 
 static int16_t resError = noErr;
 static phosg::PrefixedLogger rm_log("[ResourceManager] ");
+
+static uint16_t read_u16b(const std::string& data, size_t offset) {
+  return (static_cast<uint16_t>(static_cast<uint8_t>(data.at(offset))) << 8) |
+      static_cast<uint8_t>(data.at(offset + 1));
+}
+
+static uint32_t read_u32b(const std::string& data, size_t offset) {
+  return (static_cast<uint32_t>(static_cast<uint8_t>(data.at(offset))) << 24) |
+      (static_cast<uint32_t>(static_cast<uint8_t>(data.at(offset + 1))) << 16) |
+      (static_cast<uint32_t>(static_cast<uint8_t>(data.at(offset + 2))) << 8) |
+      static_cast<uint8_t>(data.at(offset + 3));
+}
+
+static std::string resource_fork_data_for_host_file(const std::string& host_filename, const std::string& data) {
+  static constexpr uint32_t APPLEDOUBLE_MAGIC = 0x00051607;
+  static constexpr uint32_t APPLEDOUBLE_VERSION_2 = 0x00020000;
+  static constexpr uint32_t APPLEDOUBLE_RESOURCE_FORK_ENTRY_ID = 2;
+  static constexpr size_t APPLEDOUBLE_ENTRY_TABLE_OFFSET = 26;
+  static constexpr size_t APPLEDOUBLE_ENTRY_SIZE = 12;
+
+  if (data.size() < APPLEDOUBLE_ENTRY_TABLE_OFFSET ||
+      read_u32b(data, 0) != APPLEDOUBLE_MAGIC ||
+      read_u32b(data, 4) != APPLEDOUBLE_VERSION_2) {
+    return data;
+  }
+
+  const uint16_t entry_count = read_u16b(data, 24);
+  const size_t entry_table_size = static_cast<size_t>(entry_count) * APPLEDOUBLE_ENTRY_SIZE;
+  if (APPLEDOUBLE_ENTRY_TABLE_OFFSET + entry_table_size > data.size()) {
+    throw std::runtime_error("truncated AppleDouble entry table");
+  }
+
+  for (size_t z = 0; z < entry_count; z++) {
+    const size_t entry_offset = APPLEDOUBLE_ENTRY_TABLE_OFFSET + (z * APPLEDOUBLE_ENTRY_SIZE);
+    const uint32_t entry_id = read_u32b(data, entry_offset);
+    const uint32_t fork_offset = read_u32b(data, entry_offset + 4);
+    const uint32_t fork_length = read_u32b(data, entry_offset + 8);
+    if (entry_id == APPLEDOUBLE_RESOURCE_FORK_ENTRY_ID) {
+      if (fork_offset > data.size() || fork_length > data.size() - fork_offset) {
+        throw std::runtime_error("AppleDouble resource fork entry is out of range");
+      }
+      rm_log.info_f("Extracted AppleDouble resource fork from {} (offset={}, length={})",
+          host_filename.c_str(),
+          fork_offset,
+          fork_length);
+      return data.substr(fork_offset, fork_length);
+    }
+  }
+
+  throw std::runtime_error("AppleDouble file has no resource fork entry");
+}
 
 class ResourceManager {
 public:
@@ -389,17 +443,19 @@ void FSpCreateResFile(const FSSpec* spec, OSType creator, OSType fileType, Scrip
 }
 
 int16_t FSpOpenResFile(const FSSpec* spec, SInt8 permission) {
-  auto host_filename = host_resource_filename_for_FSSpec(spec);
-  if (host_filename.empty()) {
-    auto filename = string_for_pstr<64>(spec->name);
-    rm_log.info_f("Failed to load resource file {}", filename);
-    resError = fnfErr;
-    return -1;
-  }
-
+  std::string host_filename;
   try {
+    host_filename = host_resource_filename_for_FSSpec(spec);
+    if (host_filename.empty()) {
+      auto filename = string_for_pstr<64>(spec->name);
+      rm_log.info_f("Failed to load resource file {}", filename);
+      resError = fnfErr;
+      return -1;
+    }
+
     std::string data = phosg::load_file(host_filename);
-    auto rf = std::make_shared<ResourceDASM::ResourceFile>(ResourceDASM::parse_resource_fork(data));
+    auto rf = std::make_shared<ResourceDASM::ResourceFile>(
+        ResourceDASM::parse_resource_fork(resource_fork_data_for_host_file(host_filename, data)));
     bool writable = (permission == fsCurPerm) || (permission > fsRdPerm);
     int16_t ret = rm.use(host_filename, rf, writable);
     rm_log.info_f("Loaded {} with reference number {} ({} with permission {})",
@@ -411,6 +467,10 @@ int16_t FSpOpenResFile(const FSSpec* spec, SInt8 permission) {
   } catch (const phosg::cannot_open_file&) {
     rm_log.info_f("Failed to load resource file {}", host_filename.c_str());
     resError = fnfErr;
+    return -1;
+  } catch (const std::exception& e) {
+    rm_log.info_f("Failed to parse resource file {}: {}", host_filename.c_str(), e.what());
+    resError = resFNotFound;
     return -1;
   }
 }

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -3,7 +3,6 @@
 #include <filesystem>
 #include <memory>
 #include <stddef.h>
-#include <stdint.h>
 #include <stdexcept>
 #include <string>
 
@@ -25,57 +24,6 @@
 
 static int16_t resError = noErr;
 static phosg::PrefixedLogger rm_log("[ResourceManager] ");
-
-static uint16_t read_u16b(const std::string& data, size_t offset) {
-  return (static_cast<uint16_t>(static_cast<uint8_t>(data.at(offset))) << 8) |
-      static_cast<uint8_t>(data.at(offset + 1));
-}
-
-static uint32_t read_u32b(const std::string& data, size_t offset) {
-  return (static_cast<uint32_t>(static_cast<uint8_t>(data.at(offset))) << 24) |
-      (static_cast<uint32_t>(static_cast<uint8_t>(data.at(offset + 1))) << 16) |
-      (static_cast<uint32_t>(static_cast<uint8_t>(data.at(offset + 2))) << 8) |
-      static_cast<uint8_t>(data.at(offset + 3));
-}
-
-static std::string resource_fork_data_for_host_file(const std::string& host_filename, const std::string& data) {
-  static constexpr uint32_t APPLEDOUBLE_MAGIC = 0x00051607;
-  static constexpr uint32_t APPLEDOUBLE_VERSION_2 = 0x00020000;
-  static constexpr uint32_t APPLEDOUBLE_RESOURCE_FORK_ENTRY_ID = 2;
-  static constexpr size_t APPLEDOUBLE_ENTRY_TABLE_OFFSET = 26;
-  static constexpr size_t APPLEDOUBLE_ENTRY_SIZE = 12;
-
-  if (data.size() < APPLEDOUBLE_ENTRY_TABLE_OFFSET ||
-      read_u32b(data, 0) != APPLEDOUBLE_MAGIC ||
-      read_u32b(data, 4) != APPLEDOUBLE_VERSION_2) {
-    return data;
-  }
-
-  const uint16_t entry_count = read_u16b(data, 24);
-  const size_t entry_table_size = static_cast<size_t>(entry_count) * APPLEDOUBLE_ENTRY_SIZE;
-  if (APPLEDOUBLE_ENTRY_TABLE_OFFSET + entry_table_size > data.size()) {
-    throw std::runtime_error("truncated AppleDouble entry table");
-  }
-
-  for (size_t z = 0; z < entry_count; z++) {
-    const size_t entry_offset = APPLEDOUBLE_ENTRY_TABLE_OFFSET + (z * APPLEDOUBLE_ENTRY_SIZE);
-    const uint32_t entry_id = read_u32b(data, entry_offset);
-    const uint32_t fork_offset = read_u32b(data, entry_offset + 4);
-    const uint32_t fork_length = read_u32b(data, entry_offset + 8);
-    if (entry_id == APPLEDOUBLE_RESOURCE_FORK_ENTRY_ID) {
-      if (fork_offset > data.size() || fork_length > data.size() - fork_offset) {
-        throw std::runtime_error("AppleDouble resource fork entry is out of range");
-      }
-      rm_log.info_f("Extracted AppleDouble resource fork from {} (offset={}, length={})",
-          host_filename.c_str(),
-          fork_offset,
-          fork_length);
-      return data.substr(fork_offset, fork_length);
-    }
-  }
-
-  throw std::runtime_error("AppleDouble file has no resource fork entry");
-}
 
 class ResourceManager {
 public:
@@ -403,9 +351,15 @@ static ResourceManager rm;
 // Classic Mac OS API implementation
 
 std::string host_resource_filename_for_host_filename(const std::string& host_path, bool allow_missing = false) {
-  std::string full_path = host_path + ".rsrc";
-  if (allow_missing || std::filesystem::is_regular_file(full_path)) {
-    return full_path;
+  if (allow_missing) {
+    return host_path + ".rsrc";
+  }
+
+  for (const auto* extension : {".rsrc", ".rsf"}) {
+    std::string full_path = host_path + extension;
+    if (std::filesystem::is_regular_file(full_path)) {
+      return full_path;
+    }
   }
 
   return "";
@@ -454,8 +408,14 @@ int16_t FSpOpenResFile(const FSSpec* spec, SInt8 permission) {
     }
 
     std::string data = phosg::load_file(host_filename);
-    auto rf = std::make_shared<ResourceDASM::ResourceFile>(
-        ResourceDASM::parse_resource_fork(resource_fork_data_for_host_file(host_filename, data)));
+    std::shared_ptr<ResourceDASM::ResourceFile> rf;
+    try {
+      rf = std::make_shared<ResourceDASM::ResourceFile>(
+          ResourceDASM::parse_applesingle_appledouble_resource_fork(data));
+      rm_log.info_f("Loaded AppleSingle/AppleDouble resource fork from {}", host_filename.c_str());
+    } catch (const std::runtime_error&) {
+      rf = std::make_shared<ResourceDASM::ResourceFile>(ResourceDASM::parse_resource_fork(data));
+    }
     bool writable = (permission == fsCurPerm) || (permission > fsRdPerm);
     int16_t ret = rm.use(host_filename, rf, writable);
     rm_log.info_f("Loaded {} with reference number {} ({} with permission {})",


### PR DESCRIPTION
Fixes #280.

This fixes the crash I hit when importing some older third-party scenarios, including Araman's Ring.

The scenario resource sidecar exists, but it is not always in the raw `.rsrc` shape the modern port expects. Some `.rsrc` files are AppleDouble containers, and a few old Windows scenario packages use `.rsf` sidecars instead.

This keeps the normal `.rsrc` path, unwraps AppleDouble resource-fork entry `2` when needed, and falls back to `.rsf` only when no `.rsrc` exists.

This does not add new scenario data behavior. It just lets the existing resource manager see the resource fork data those scenarios already shipped with and prevents the crash on import as a result.