### PR TITLE
Fix Drop All Equipment inventory handling

### DIFF
--- a/src/realmz_orig/newland.c
+++ b/src/realmz_orig/newland.c
@@ -1009,12 +1009,12 @@ startover:
 
       case 91: /***** Drop all equipment ****/
         for (loop = 0; loop <= charnum; loop++) {
-          itemcount = -1;
-          while (c[loop].numitems) {
-            itemcount++;
-            removeitem(loop, itemcount, FALSE, TRUE);
-            dropitem(loop, c[loop].items[1].id, 0, 141, TRUE);
-          }
+          /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+           * The original loop advanced itemcount, then dropped slot 0 using
+           * slot 1's id. Drop slot 0 repeatedly so remove/drop stay in sync.
+           */
+          while (c[loop].numitems)
+            dropitem(loop, c[loop].items[0].id, 0, 141, TRUE);
         }
 
         shortupdate(0);


### PR DESCRIPTION
Fixes #255.

The Drop All Equipment encounter path was removing inventory slot 0, but passing a different item id to `dropitem()`.

That usually still empties the visible inventory, but it can leave the character's tracked load wrong because `dropitem()` subtracts weight using the item id it was given.

This changes opcode 91 to keep dropping the current slot 0 until the character has no items left, so the removed slot and dropped item id stay in sync.
