### PR TITLE
Handle missing resources consistently

### DIFF
--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -48,6 +48,9 @@ Font load_font(int16_t font_id) {
     return bm_renderers_by_id.at(font_id);
   } catch (const std::out_of_range&) {
     auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_FONT, font_id);
+    if (!data_handle) {
+      throw std::out_of_range(std::format("FONT resource {} not found", font_id));
+    }
     auto decoded =
         std::make_shared<ResourceDASM::ResourceFile::DecodedFontResource>(
             ResourceDASM::ResourceFile::decode_FONT_only(

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -25,6 +25,9 @@ public:
     if (!this->res_id_to_menu.contains(res_id)) {
       mm_log.info_f("Loading MENU:{} from resource forks", res_id);
       auto handle = GetResource(ResourceDASM::RESOURCE_TYPE_MENU, res_id);
+      if (!handle) {
+        throw std::out_of_range("MENU resource not found");
+      }
       auto decoded_menu = ResourceFile::decode_MENU(*handle, GetHandleSize(handle));
       auto menu = std::make_shared<Menu>(Menu(decoded_menu));
       this->res_id_to_menu.emplace(res_id, menu);
@@ -158,6 +161,9 @@ static MenuManager mm;
 Handle GetNewMBar(int16_t menuBarID) {
   mm_log.info_f("Loading MBAR:{} from resource forks", menuBarID);
   auto handle = GetResource(ResourceDASM::RESOURCE_TYPE_MBAR, menuBarID);
+  if (!handle) {
+    throw std::out_of_range("MBAR resource not found");
+  }
   mm.load_menu_list(handle);
   return handle;
 }

--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -814,6 +814,9 @@ void RGBForeColor(const RGBColor* color) {
 
 CIconHandle GetCIcon(uint16_t iconID) {
   auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_cicn, iconID);
+  if (!data_handle) {
+    throw std::runtime_error(std::format("cicn resource {} not found", iconID));
+  }
   auto decoded_cicn = ResourceDASM::ResourceFile::decode_cicn(*data_handle, GetHandleSize(data_handle));
 
   CIconHandle h = NewHandleTyped<CIcon>();
@@ -1177,6 +1180,9 @@ CCrsrHandle GetCCursor(uint16_t resource_id) {
   cursor.resource_id = resource_id;
 
   auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_crsr, resource_id);
+  if (!data_handle) {
+    throw std::runtime_error(std::format("crsr resource {} not found", resource_id));
+  }
   cursor.decoded = std::make_shared<ResourceDASM::ResourceFile::DecodedColorCursorResource>(
       ResourceDASM::ResourceFile::decode_crsr(*data_handle, GetHandleSize(data_handle)));
 

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -271,14 +271,6 @@ public:
       }
     }
 
-    if (type == ResourceDASM::RESOURCE_TYPE_snd) {
-      // TODO: Some action points seem to specify invalid sound resources by id, such as
-      // 0 (which should be the system beep, but which we haven't implemented). If we can't
-      // find the snd resource, we simply return nullptr here, which causes PlaySound to not
-      // play anything.
-      return nullptr;
-    }
-
     std::string type_str = ResourceDASM::string_for_resource_type(type);
     rm_log.info_f("{}:{} not found in any open resource file", type_str, id);
     this->print_chain();
@@ -562,14 +554,16 @@ void UpdateResFile(int16_t refnum) {
 }
 
 Handle GetResource(ResType type, int16_t id) {
-  auto res = rm.get_resource(type, id);
-  if (res != nullptr) {
-    resError = noErr;
-    return res->data_handle;
+  std::shared_ptr<ResourceManager::Resource> res;
+  try {
+    res = rm.get_resource(type, id);
+  } catch (const std::out_of_range&) {
+    resError = resNotFound;
+    return nullptr;
   }
 
-  resError = resNotFound;
-  return nullptr;
+  resError = noErr;
+  return res->data_handle;
 }
 
 Handle Get1Resource(ResType type, int16_t id) {
@@ -602,14 +596,15 @@ Handle Get1Resource(ResType type, int16_t id) {
 }
 
 int32_t GetResourceSizeOnDisk(Handle data_handle) {
-  auto res = rm.get_resource(data_handle);
-  if (res != nullptr) {
-    resError = noErr;
-    return GetHandleSize(data_handle);
+  try {
+    rm.get_resource(data_handle);
+  } catch (const std::out_of_range&) {
+    resError = resNotFound;
+    return -1;
   }
 
-  resError = resNotFound;
-  return -1;
+  resError = noErr;
+  return GetHandleSize(data_handle);
 }
 
 void ReleaseResource(Handle data_handle) {

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -221,6 +221,9 @@ public:
   // Create a new control from a resource. This implements the GetNewControl syscall.
   static std::shared_ptr<Control> from_CNTL(int16_t cntl_resource_id) {
     auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_CNTL, cntl_resource_id);
+    if (!data_handle) {
+      throw std::runtime_error(std::format("CNTL resource {} not found", cntl_resource_id));
+    }
     auto def = ResourceDASM::ResourceFile::decode_CNTL(*data_handle, GetHandleSize(data_handle));
     Rect bounds = copy_rect(def.bounds);
     return Control::make_shared(cntl_resource_id, bounds, def.value, def.min, def.max, def.proc_id, def.visible, def.title);
@@ -374,6 +377,9 @@ public:
   // Create a list of dialog items from a DITL resource
   static std::vector<std::shared_ptr<DialogItem>> from_DITL(int16_t ditl_resource_id) {
     auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_DITL, ditl_resource_id);
+    if (!data_handle) {
+      throw std::runtime_error(std::format("DITL resource {} not found", ditl_resource_id));
+    }
     auto defs = ResourceDASM::ResourceFile::decode_DITL(*data_handle, GetHandleSize(data_handle));
 
     std::vector<std::shared_ptr<DialogItem>> ret;
@@ -1745,6 +1751,9 @@ WindowPtr WindowManager_CreateNewWindow(int16_t res_id, bool is_dialog, WindowPt
 
   if (is_dialog) {
     auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_DLOG, res_id);
+    if (!data_handle) {
+      throw std::runtime_error(std::format("DLOG resource {} not found", res_id));
+    }
     auto dlog = ResourceDASM::ResourceFile::decode_DLOG(*data_handle, GetHandleSize(data_handle));
     bounds.left = dlog.bounds.x1;
     bounds.right = dlog.bounds.x2;
@@ -1759,6 +1768,9 @@ WindowPtr WindowManager_CreateNewWindow(int16_t res_id, bool is_dialog, WindowPt
 
   } else {
     auto data_handle = GetResource(ResourceDASM::RESOURCE_TYPE_WIND, res_id);
+    if (!data_handle) {
+      throw std::runtime_error(std::format("WIND resource {} not found", res_id));
+    }
     auto wind = ResourceDASM::ResourceFile::decode_WIND(*data_handle, GetHandleSize(data_handle));
     bounds.left = wind.bounds.x1;
     bounds.right = wind.bounds.x2;


### PR DESCRIPTION
Addresses #78.

Realmz had mixed missing-resource behavior in the modern ResourceManager layer. Some missing resources returned `nullptr`, but others threw before original-style callers could handle the missing resource themselves.

That made optional missing resources fatal in places that already had null checks. Trial By Fire exposed this with a Show Pict action that references a missing PICT resource; Classic Mac Realmz skips it, but the current port crashed before `GetPicture()` could return `nullptr`.

This changes `GetResource()` and `GetResourceSizeOnDisk()` to use the Classic-style missing-resource behavior: set `resNotFound` and return `nullptr` / `-1`.

Since some modern wrapper code was implicitly relying on `GetResource()` throwing, this also adds explicit null checks before decoding required resources such as fonts, menus, icons, cursors, controls, dialogs, and windows. Optional resources can now be skipped cleanly, while required resources still fail clearly.

Verified with a Windows build and Trial By Fire. The scenario no longer crashes on the missing picture reference.

