### PR TITLE
Guard class 6 monster saves

### DIFF
--- a/src/realmz_orig/misc.c
+++ b/src/realmz_orig/misc.c
@@ -1210,7 +1210,10 @@ short savevs(short which, short who) {
       special /= 6;
       if (temp <= special + spelladjust)
         return (TRUE);
-    } else {
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * Monster save and spellimmune arrays only store classes 0-5.
+     */
+    } else if ((which > -1) && (which < 6)) {
       if ((temp <= monster[who - 10].save[which] + spelladjust) || (monster[who - 10].spellimmune[which]))
         return (TRUE);
       if ((monster[who - 10].type[1]) && ((which == 5) || (which == 4) || (which == 0)))


### PR DESCRIPTION
Fixes #286.

Follow-up to #276.

#276 fixed the direct class 6 resistance check, but `savevs()` still had the same monster array boundary issue when a class 6 spell reached the normal saving throw path.

Monster save and spell immunity arrays only store classes 0-5. A `savevs(6, monster)` call could read one slot past those arrays instead of treating class 6 as having no matching monster save/immunity entry.

This keeps the existing special `which == 7` aggregate save behavior unchanged, and only guards the normal monster save/immunity lookup to valid stored classes.

Verified with a Windows Debug build.