### PR TITLE
fix monster DRV and immunity indexing in savevs

### DIFF
--- a/src/realmz_orig/misc.c
+++ b/src/realmz_orig/misc.c
@@ -1211,7 +1211,14 @@ short savevs(short which, short who) {
       if (temp <= special + spelladjust)
         return (TRUE);
     } else {
-      if ((temp <= monster[who - 10].save[which] + spelladjust) || (monster[who - 10].spellimmune[which]))
+      /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+       * NOTE(chromancer) Monster save and spellimmune arrays are indexed differently,
+       * so two checks are required to use the correct values in data and avoid out-of-bounds
+       * reads that cause incorrect save and immunity calcs.
+       */
+      if ((which < 6) && (monster[who - 10].spellimmune[which]))
+        return (TRUE);
+      if ((which > 0) && (temp <= monster[who - 10].save[which - 1] + spelladjust))
         return (TRUE);
       if ((monster[who - 10].type[1]) && ((which == 5) || (which == 4) || (which == 0)))
         return (TRUE);


### PR DESCRIPTION
issue: credit to kanhef on discord for the find. Fixes #286. Fix supersedes #287 and completes #276

Basically, no monster is using its correct saves, and in places this results in not just incorrect use of wrong DRVs but some of those are OOB reads

cause: spellimmune[]'s first field is charm and nothing is immune to magic (handled by MR). But save[] is heat..magic and charm is handled by spellimmune[0]. savevs() acts as if both are charm-first. OK for spellimmune, save[] is off by one, read OOB in both: save[6] reads charm-immunity, and spellimmune[6] reads gold.

vulnerability check in resolvespell.c already uses save[damagetype - 1]
bestiary/combat-info display code draws save[] starting one row down.

fix:
* index save[] with which - 1, guarded by `which > 0 ` (charm is still covered by immunity, undead, and the charm formula in resist itself)
* spellimmune[] looks up guarded by `which < 6`

effects:
* Monsters save in the way intended by data
* Monster saves can no longer go out of bounds

testing: builds fine and changes nothing structurally. This was always more or less invisible unless you were running pragmatic testing in-game. I can confirm that behaviors with different enemies are much more sane.