### PR TITLE
calculate all equipment bonuses correctly

### DIFF
--- a/src/realmz_orig/attack.c
+++ b/src/realmz_orig/attack.c
@@ -12,7 +12,7 @@ short attack(short chare, short mon) {
   Boolean kill = 0;
   struct character character;
   struct monster monst;
-  short att, specialdam;
+  short att, specialdam, equippedbonus;
   short t;
   char addcond, amountcond, whichcond;
   Boolean success;
@@ -39,6 +39,18 @@ short attack(short chare, short mon) {
   }
 
   drawbody(chare, 1, 0); /***** This is to change fancing and highlight player prior to attack **** 0 = look, 1 = buff ******/
+
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(chromancer) Against apparent original intent, the source implementation did not
+   * correctly account for damage or to-hit bonuses from equipped items or weapons.
+   * See inline comments 1, 2 and 3.
+   */
+  equippedbonus = 0; // 1: Sum over character's items for all granted to-hit.
+  for (t = 0; (t < c[chare].numitems) && (t < 30); t++)
+    if (c[chare].items[t].equip) {
+      loaditem(c[chare].items[t].id);
+      equippedbonus += item.damage;
+    }
 
   if (character.armor[2]) {
     loaditem(character.armor[2]);
@@ -68,15 +80,7 @@ short attack(short chare, short mon) {
         }
       }
     }
-    damage += item.damage; /******* magic plus ****/
-    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-     * The weapon magic plus (item.damage) was added to player melee damage but
-     * never to the to-hit roll. The monster path (attack2) and missile path
-     * (resolvespell) both add 5 per point, and the character sheet attack bonus
-     * already includes it (damage * 5), so player melee was the only path that
-     * ignored it. Add the same term here. */
-    att += 5 * item.damage; /******* magic plus to hit; matches attack2 and resolvespell ****/
-    /* *** END CHANGES *** */
+    // 2: Original line that added damage removed here because damage is already summed in character.damage.
     if (item.sp1 == 121)
       att += 5 * item.damage; /******* double to hit weapon ****/
 
@@ -102,6 +106,7 @@ short attack(short chare, short mon) {
 
 moveon:
   att += (50 + character.tohit + 20 * behind);
+  att += 5 * equippedbonus; // 3: Add to-hit bonus here, reachable for armed, unarmed, and COND_ANIMATED paths.
   if (character.condition[COND_TANGLED])
     att -= abs(character.condition[COND_TANGLED]); /*** tangled ***/
   if (character.condition[COND_STRONG])

--- a/src/realmz_orig/attack.c
+++ b/src/realmz_orig/attack.c
@@ -43,12 +43,12 @@ short attack(short chare, short mon) {
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
    * NOTE(chromancer) Against apparent original intent, the source implementation did not
    * correctly account for damage or to-hit bonuses from equipped items or weapons.
-   * See inline comments 1, 2 and 3.
+   * See inline comments 1, 2, 3, and 4.
    */
   equippedbonus = 0; // 1: Sum over character's items for all granted to-hit.
-  for (t = 0; (t < c[chare].numitems) && (t < 30); t++)
-    if (c[chare].items[t].equip) {
-      loaditem(c[chare].items[t].id);
+  for (t = 0; (t < character.numitems) && (t < 30); t++)
+    if (character.items[t].equip) {
+      loaditem(character.items[t].id);
       equippedbonus += item.damage;
     }
 
@@ -102,11 +102,12 @@ short attack(short chare, short mon) {
         whichcond = item.sp3;
       }
     }
-  }
+  } else
+    loaditem(0); // 3: Load null item to avoid passing results of our loop to later checks.
 
 moveon:
   att += (50 + character.tohit + 20 * behind);
-  att += 5 * equippedbonus; // 3: Add to-hit bonus here, reachable for armed, unarmed, and COND_ANIMATED paths.
+  att += 5 * equippedbonus; // 4: Add to-hit bonus here, reachable for armed, unarmed, and COND_ANIMATED paths.
   if (character.condition[COND_TANGLED])
     att -= abs(character.condition[COND_TANGLED]); /*** tangled ***/
   if (character.condition[COND_STRONG])


### PR DESCRIPTION
updated after review comments

This PR addresses the logic of #289. Close #269, close #274, replaces approach of #268 and #275. kudos @afkelsall for finding the brawn double count. I also expand scope to null the global item and prevent the original behavior of passing stale unintended data to the later unguarded checks.

This resolves all bonuses as intended in the manual and what we can recover of the code intent.

fix:
* sum item.damage over the character's equipped items at the top of attack(), using items[].equip flags. No stored stat has this.
* add 5 times sum to att in the shared path after the base to-hit, so armed, unarmed, and animated attackers all get it.
* remove #268's weapon branch add of to-hit, since any equipped weapon is already in the sum.
* remove duplicate damage add at attack.c:71, since weapon damage already comes with character.damage.
* load a null item into the global item

effects:
* enchanted weapons get damage bonus once
* enchanted weapons get to-hit bonus once
* worn items now add to-hit
* unarmed attacks cannot inherit stale item data and use it to pass unguarded checks

The thing I don't like but is consistent: items equipped in the missile/quiver slots count toward melee to-hit. Yes, equipping a bow with enchant added melee damage in orig realmz, and under this PR it also adds melee to-hit. We should discuss this as a later issue; it defies common sense.

testing: built on Mac. Tested with ad hoc logging backwards and forwards.