### PR TITLE
fix attack & defense bonus in UI

### DIFF
--- a/src/realmz_orig/showstats.c
+++ b/src/realmz_orig/showstats.c
@@ -3,7 +3,8 @@
 
 /***************************** ShowStats ********************************/
 void ShowStats(short showprestige) {
-  short t, conditionindex = 0;
+  short t, conditionindex = 0, equipped;
+  struct itemattr saveditem;
   int32_t prestige = 0;
   char special[50], specialindex;
 
@@ -44,24 +45,45 @@ void ShowStats(short showprestige) {
   DialogNum(23, characterl.co + characterl.magco);
   DialogNum(24, characterl.lu + characterl.maglu);
 
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+  * NOTE(chromancer): Original displayed attack bonus (to-hit) as "(some) conditions + character.damage * 5",
+  * not accurate to game combat logic or intended behavior. Following original intent, we:
+  * Calculate the attack bonus from conditions, base to-hit, then 5 * equipped (double for penetration)
+  * Complete the defense bonus to match the manual's "all spell effects, conditions".
+  */
+  saveditem = item;
+  equipped = 0;
+  for (t = 0; (t < characterl.numitems) && (t < 30); t++)
+    if (characterl.items[t].equip) {
+      loaditem(characterl.items[t].id);
+      equipped += item.damage;
+      if (item.sp1 == 121)
+        equipped += item.damage; // Double to-hit for penetration
+    }
+  item = saveditem;
+
   temp = 0;
   if (characterl.condition[COND_STRONG])
     temp += 15; /**** strong ***/
   if (characterl.condition[COND_SLOW])
     temp -= 15; /**** slow ***/
+  if (characterl.condition[COND_CONFUSED])
+    temp -= 10;
+  if (characterl.condition[COND_BLIND])
+    temp -= 15;
   if (characterl.condition[COND_MAGIC_AURA])
-    temp += 5; /**** bless ***/
+    temp += 5;
   if (characterl.condition[COND_CURSED])
     temp -= 5; /**** curse ***/
   if (characterl.condition[COND_TANGLED])
     temp -= abs(characterl.condition[COND_TANGLED]); /*** tangled ***/
   if (characterl.condition[COND_HINDERED_ATTACKS])
     temp -= abs(characterl.condition[COND_HINDERED_ATTACKS]); /*** Hinder atk ***/
-  temp += (characterl.damage * 5); /*** Hinder atk ***/
+  temp += characterl.tohit + (5 * equipped);
 
   if (temp > 99)
     TextSize(16);
-  DialogNum(25, temp); /*** attack bonus ****/
+  DialogNum(25, temp); // Total displayed to-hit bonus (UI label "Attack Bonus").
   TextSize(20);
 
   temp = 0;
@@ -69,18 +91,26 @@ void ShowStats(short showprestige) {
     temp += 10; /*** invisible ***/
   if (characterl.condition[COND_SLOW])
     temp -= 15; /*** slow ***/
+  if (characterl.condition[COND_CONFUSED])
+    temp -= 10;
+  if (characterl.condition[COND_BLIND])
+    temp -= 15;
   if (characterl.condition[COND_MAGIC_AURA])
-    temp += 5; /*** bless ***/
+    temp += 5;
   if (characterl.condition[COND_CURSED])
     temp -= 5; /*** curse ***/
+  if (characterl.condition[COND_TANGLED])
+    temp -= abs(characterl.condition[COND_TANGLED]);
   if (characterl.condition[COND_HINDERED_DEFENSE])
     temp -= abs(characterl.condition[COND_HINDERED_DEFENSE]); /*** hinder defense ***/
   if (characterl.condition[COND_DEFENSE_BONUS])
-    temp += abs(characterl.condition[COND_DEFENSE_BONUS]); /*** defense bonus ***/
-  temp += characterl.ac; /*** Hinder atk ***/
+    temp += abs(characterl.condition[COND_DEFENSE_BONUS]);
+  temp += characterl.ac;
+  if (characterl.condition[COND_SHIELD_FROM_HITS])
+    temp += 2 * abs(characterl.condition[COND_SHIELD_FROM_HITS]);
   if (temp > 99)
     TextSize(16);
-  DialogNum(26, temp); /*** defense bonus ****/
+  DialogNum(26, temp); // Total displayed defense bonus (UI label "Defense Bonus").
   TextSize(20);
 
   templong = characterl.age / 365;

--- a/src/realmz_orig/updatecharinfo.c
+++ b/src/realmz_orig/updatecharinfo.c
@@ -6,7 +6,8 @@ void updatecharinfo(void) {
   int enable_recomposite = WindowManager_SetEnableRecomposite(0);
 
   GrafPtr oldport;
-  short temp, conditionindex = 0;
+  short temp, conditionindex = 0, equipped;
+  struct itemattr saveditem;
   GetPort(&oldport);
   SetPortDialogPort(charstat);
 
@@ -22,43 +23,73 @@ void updatecharinfo(void) {
   DialogNum(8, c[charselectnew].de);
   DialogNum(9, c[charselectnew].co + c[charselectnew].magco);
   DialogNum(10, c[charselectnew].lu + c[charselectnew].maglu);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+  * NOTE(chromancer): Original displayed attack bonus (to-hit) as "(some) conditions + character.damage * 5",
+  * not accurate to game combat logic or intended behavior. Following original intent, we:
+  * Calculate the attack bonus from conditions, base to-hit, then 5 * equipped (double for penetration)
+  * Add absolute values for conditions that use negative values to indicate permanent status.
+  * Complete the defense bonus to match the manual's "all spell effects, conditions".
+  */
+  saveditem = item;
+  equipped = 0;
+  for (t = 0; (t < c[charselectnew].numitems) && (t < 30); t++)
+    if (c[charselectnew].items[t].equip) {
+      loaditem(c[charselectnew].items[t].id);
+      equipped += item.damage;
+      if (item.sp1 == 121)
+        equipped += item.damage; // Double to-hit for penetration
+    }
+  item = saveditem;
 
   temp = 0;
-  if (characterl.condition[COND_STRONG])
+  if (c[charselectnew].condition[COND_STRONG])
     temp += 15; /**** strong ***/
-  if (characterl.condition[COND_SLOW])
+  if (c[charselectnew].condition[COND_SLOW])
     temp -= 15; /**** slow ***/
-  if (characterl.condition[COND_MAGIC_AURA])
-    temp += 5; /**** bless ***/
-  if (characterl.condition[COND_CURSED])
+  if (c[charselectnew].condition[COND_CONFUSED])
+    temp -= 10;
+  if (c[charselectnew].condition[COND_BLIND])
+    temp -= 15;
+  if (c[charselectnew].condition[COND_MAGIC_AURA])
+    temp += 5;
+  if (c[charselectnew].condition[COND_CURSED])
     temp -= 5; /**** curse ***/
-  if (characterl.condition[COND_TANGLED])
-    temp -= characterl.condition[COND_TANGLED]; /*** tangled ***/
-  if (characterl.condition[COND_HINDERED_ATTACKS])
-    temp -= characterl.condition[COND_HINDERED_ATTACKS]; /*** Hinder atk ***/
-  temp += (characterl.damage * 5); /*** Hinder atk ***/
+  if (c[charselectnew].condition[COND_TANGLED])
+    temp -= abs(c[charselectnew].condition[COND_TANGLED]); /*** tangled ***/
+  if (c[charselectnew].condition[COND_HINDERED_ATTACKS])
+    temp -= abs(c[charselectnew].condition[COND_HINDERED_ATTACKS]); /*** Hinder atk ***/
+  temp += c[charselectnew].tohit + (5 * equipped);
   if (temp > 99)
     TextSize(16);
-  DialogNum(11, temp); /*** attack bonus ****/
+  DialogNum(11, temp); // Total displayed to-hit bonus (UI label "Attack Bonus").
   TextSize(20);
 
   temp = 0;
-  if (characterl.condition[COND_INVISIBLE])
+  if (c[charselectnew].condition[COND_INVISIBLE])
     temp += 10; /*** invisible ***/
-  if (characterl.condition[COND_SLOW])
+  if (c[charselectnew].condition[COND_SLOW])
     temp -= 15; /*** slow ***/
-  if (characterl.condition[COND_MAGIC_AURA])
-    temp += 5; /*** bless ***/
-  if (characterl.condition[COND_CURSED])
+  if (c[charselectnew].condition[COND_CONFUSED])
+    temp -= 10;
+  if (c[charselectnew].condition[COND_BLIND])
+    temp -= 15;
+  if (c[charselectnew].condition[COND_MAGIC_AURA])
+    temp += 5;
+  if (c[charselectnew].condition[COND_CURSED])
     temp -= 5; /*** curse ***/
-  if (characterl.condition[COND_HINDERED_DEFENSE])
-    temp -= characterl.condition[COND_HINDERED_DEFENSE]; /*** hinder defense ***/
-  if (characterl.condition[COND_DEFENSE_BONUS])
-    temp += characterl.condition[COND_DEFENSE_BONUS]; /*** defense bonus ***/
-  temp += characterl.ac; /*** Hinder atk ***/
+  if (c[charselectnew].condition[COND_TANGLED])
+    temp -= abs(c[charselectnew].condition[COND_TANGLED]);
+  if (c[charselectnew].condition[COND_HINDERED_DEFENSE])
+    temp -= abs(c[charselectnew].condition[COND_HINDERED_DEFENSE]); /*** hinder defense ***/
+  if (c[charselectnew].condition[COND_DEFENSE_BONUS])
+    temp += abs(c[charselectnew].condition[COND_DEFENSE_BONUS]);
+  temp += c[charselectnew].ac;
+  if (c[charselectnew].condition[COND_SHIELD_FROM_HITS])
+    temp += 2 * abs(c[charselectnew].condition[COND_SHIELD_FROM_HITS]);
   if (temp > 99)
     TextSize(16);
-  DialogNum(12, temp); /*** defense bonus ****/
+  DialogNum(12, temp); // Total displayed defense bonus (UI label "Defense Bonus").
+  
   TextSize(20);
   ForeColor(yellowColor);
   DialogNum(26, c[charselectnew].movementmax);


### PR DESCRIPTION
updated with review comments

UI half of #289. Depends on #290, should not be merged otherwise. Completes #210.

In both the big character sheet and the half-size panel, we now correct and standardize the display of attack and defense bonuses as the manual says it ought to be.

fix:
* Attack Bonus = tohit + 5 times equipped + full condition list (confused/blind added), done exactly as attack() does under #290
* Defense Bonus includes its missing conditions: confused, blind, tangled, shield-from-hits
* abs() on condition values in updatecharinfo.c to match. Permanent conditions store negative values. #210 fixed showstats and missed this file.
* detect and add double to-hit of penetration weapons
* update file to use c[charselectnew] instead of characterl, which is stale and not refreshed here (original bug)

effects:
* both screens agree with each other and with logic
* Attack Bonus changes for every character.

note I stash the global item around the sum here. There's a lot of paths to audit.

Things I don't like: the equipped sum is now hand-copied in three places. I did not want to burden this with adding game logic functions for which there is no clean precedent but if I was writing the game from scratch…

testing: built on Mac. Values verified by hand, screens agree, and are valid against the new values from #290.