### PR TITLE
Consistent handling of stat changes

### DIFF
--- a/src/realmz_orig/age.c
+++ b/src/realmz_orig/age.c
@@ -130,14 +130,14 @@ void applyage(short raceid, short agegroup, short direction) {
 
   characterl.currentagegroup = agegroup;
 
-  strength(characterl.st);
+  strength(characterl.st + characterl.magst);
   characterl.tohit -= temp;
   characterl.damage -= damage;
   updatespec(2);
   
   characterl.st += direction * races.agechange[agegroup - 1][0];
 
-  strength(characterl.st);
+  strength(characterl.st + characterl.magst);
   characterl.tohit += temp;
   characterl.damage += damage;
   updatespec(3);

--- a/src/realmz_orig/age.c
+++ b/src/realmz_orig/age.c
@@ -123,24 +123,60 @@ void showageupdate(short who, short agegroup, short backup) {
 void applyage(short raceid, short agegroup, short direction) {
   short t;
 
-  loadprofile(raceid, 0);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(orthotope): recalculate stats based on changes
+   */
+  loadprofile(raceid, characterl.caste);
 
   characterl.currentagegroup = agegroup;
 
   strength(characterl.st);
   characterl.tohit -= temp;
   characterl.damage -= damage;
-
+  updatespec(2);
+  
   characterl.st += direction * races.agechange[agegroup - 1][0];
 
   strength(characterl.st);
   characterl.tohit += temp;
   characterl.damage += damage;
+  updatespec(3);
 
+  if (characterl.in > 15)
+    characterl.magres -= caste.magres * (characterl.in - 15);
   characterl.in += direction * races.agechange[agegroup - 1][1];
+  if (characterl.in > 15)
+    characterl.magres += caste.magres * (characterl.in - 15);
+
+  if (characterl.wi > 15)
+    characterl.magres -= caste.magres * (characterl.wi - 15);
   characterl.wi += direction * races.agechange[agegroup - 1][2];
+  if (characterl.wi > 15)
+    characterl.magres += caste.magres * (characterl.wi - 15);
+
+  characterl.dodge -= 2 * characterl.de;
+  if (characterl.de > 14)
+    characterl.ac -= 2 * (characterl.de - 14);
+  updatespec(2);
   characterl.de += direction * races.agechange[agegroup - 1][3];
+  characterl.dodge += 2 * characterl.de;
+  if (characterl.de > 14)
+    characterl.ac += 2 * (characterl.de - 14);
+  updatespec(3);
+
+  if (characterl.co > 18) {
+    for (t = 0; t < 8; t++) {
+      characterl.save[t] -= 5 * (characterl.co - 18);
+    }
+  }
   characterl.co += direction * races.agechange[agegroup - 1][4];
+  if (characterl.co > 18) {
+    for (t = 0; t < 8; t++) {
+      characterl.save[t] += 5 * (characterl.co - 18);
+    }
+  }
+  /* end changes */
+
   characterl.lu += direction * races.agechange[agegroup - 1][5];
 
   characterl.magres += direction * races.agechange[agegroup - 1][6];

--- a/src/realmz_orig/misc.c
+++ b/src/realmz_orig/misc.c
@@ -472,7 +472,11 @@ void strength(short st) {
         damage = 8;
         break;
 
+      /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+      * NOTE(orthotope): add default case to handle strength over 30 gracefully
+      */
       case 30:
+      default:
         temp = 40;
         damage = 8;
         break;

--- a/src/realmz_orig/newcharacter.c
+++ b/src/realmz_orig/newcharacter.c
@@ -249,7 +249,16 @@ waynew:
      * been moved (see my comment above) to fix a bug related to age modifier application.
      */
 
+     /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(orthotope): Increasing knowledge and judgment above 15 via improvement potions adds magic resistance. 
+     * Adding that here as well to not penalize characters for having good starting stats.
+     */
     characterl.magres = (characterl.in + characterl.wi) / 10;
+    if (characterl.in > 15)
+      characterl.magres += characterl.in - 15;
+    if (characterl.wi > 15)
+      characterl.magres += characterl.wi - 15;
+    /* end changes */
 
     characterl.magres *= caste.magres; /************ caste.magres must be 1 or higher *********/
 
@@ -268,7 +277,17 @@ waynew:
       characterl.missile = 0;
 
     characterl.movementmax = races.basemove + caste.movebonus;
-
+    
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(orthotope): Increasing vitality above 18 via improvement potions adds to DR Vs.
+     * Adding that here to not penalize characters for having good starting stats.
+     */
+    if (characterl.co > 18) {
+      for (t = 0; t < 8; t++) {
+        characterl.save[t] += 5 * (characterl.co - 18);
+      }
+    }
+    /* end changes */
     for (t = 0; t < 8; t++) {
       if (characterl.save[t] < -99)
         characterl.save[t] = -99;

--- a/src/realmz_orig/removeitem.c
+++ b/src/realmz_orig/removeitem.c
@@ -100,7 +100,21 @@ short removeitem(short character, short itemnum, short play, short force) {
   }
 
   c[character].items[itemnum].equip = FALSE;
-  c[character].magst -= item.st;
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(orthotope): update strength-based stats
+   */
+  if (item.st) {
+    strength(c[character].st + c[character].magst);
+    c[character].damage -= damage;
+    c[character].tohit -= temp;
+    updatespec(2);
+    c[character].magst -= item.st;
+    strength(c[character].st + c[character].magst);
+    c[character].damage += damage;
+    c[character].tohit += temp;
+    updatespec(3);
+  }
+  /* end changes */
   c[character].maglu -= item.lu;
   c[character].magres -= item.magres;
   if (c[character].ac - item.ac > 0)

--- a/src/realmz_orig/resolvespell.c
+++ b/src/realmz_orig/resolvespell.c
@@ -179,6 +179,10 @@ void resolvespell(void) {
                 for (tt = 0; tt < 8; tt++)
                   c[t].save[tt] += 5;
               break;
+
+            case 6: /***** Luck ****/
+              c[t].lu++;
+              break;
             /* end changes */
 
             case 10: /***** Stamina ****/

--- a/src/realmz_orig/resolvespell.c
+++ b/src/realmz_orig/resolvespell.c
@@ -139,13 +139,13 @@ void resolvespell(void) {
      */
           switch (spellinfo.size) {
             case 1: /***** Brawn ****/
-              strength(c[t].st);
+              strength(c[t].st + c[t].magst);
               c[t].damage -= damage;
               c[t].tohit -= temp;
               updatespec(2);
 
               c[t].st++;
-              strength(c[t].st);
+              strength(c[t].st + c[t].magst);
               c[t].damage += damage;
               c[t].tohit += temp;
               updatespec(3);

--- a/src/realmz_orig/resolvespell.c
+++ b/src/realmz_orig/resolvespell.c
@@ -131,43 +131,55 @@ void resolvespell(void) {
         attr = &c[t].st;
         attr += (spellinfo.size - 1);
         if (*attr < 25) {
-          *attr += 1;
-
+     /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(orthotope): Originally *attr was incremented here, which would write into the Sorcerer spell list
+     * when using improved stamina or increased spell points. Moved into switch statement to only increase desired stats.
+     * 
+     * Recalculate special abilities based on brawn and agility.
+     */
           switch (spellinfo.size) {
             case 1: /***** Brawn ****/
-              c[t].st--;
-
               strength(c[t].st);
               c[t].damage -= damage;
               c[t].tohit -= temp;
+              updatespec(2);
 
               c[t].st++;
               strength(c[t].st);
               c[t].damage += damage;
               c[t].tohit += temp;
+              updatespec(3);
 
               break;
 
             case 2: /***** Knowledge ****/
+              c[t].in++;
               if (c[t].in > 15)
                 c[t].magres += caste.magres;
               break;
 
             case 3: /***** Judgment ****/
+              c[t].wi++;
               if (c[t].wi > 15)
                 c[t].magres += caste.magres;
               break;
 
             case 4: /***** Agility ****/
+              updatespec(2);
+              c[t].de++;
+              updatespec(3);
+              c[t].dodge += 2;
               if (c[t].de > 14)
                 c[t].ac += 2;
               break;
 
             case 5: /***** Vitality ****/
+              c[t].co++;
               if (c[t].co > 18)
                 for (tt = 0; tt < 8; tt++)
                   c[t].save[tt] += 5;
               break;
+            /* end changes */
 
             case 10: /***** Stamina ****/
               c[t].staminamax += Rand(8);

--- a/src/realmz_orig/updatespec.c
+++ b/src/realmz_orig/updatespec.c
@@ -76,6 +76,53 @@ void updatespec(short mode) {
         }
 
       break;
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(orthotope): Add cases 2 and 3 to remove and re-add brawn and agility-based modifiers.
+     * Includes magic strength from items in calculation.
+     * Also add bounds-checking on range array, in case someone manages to get wildly high or low stats.
+     */
+    case 2: /*** remove ***/
+      for (tt = 0; tt < 19; tt++)
+      {
+        if (range1[tt] == (characterl.st + characterl.magst)
+          || (tt == 0 && characterl.st + characterl.magst < 3)
+          || (tt == 18 && characterl.st + characterl.magst > 30) ) {
+          for (t = 0; t < 14; t++)
+            if (caste.specialability[0][t])
+              characterl.spec[t] -= stmodif[t][tt];
+        }
+      }
+
+      for (tt = 0; tt < 19; tt++)
+        if (range1[tt] == characterl.de || tt == 0 && characterl.de < 3 || tt == 18 && characterl.de > 30) {
+          for (t = 0; t < 14; t++)
+            if (caste.specialability[0][t])
+              characterl.spec[t] -= demodif[t][tt];
+        }
+
+      break;
+    
+    case 3: /*** re-add ***/
+      for (tt = 0; tt < 19; tt++)
+      {
+        if (range1[tt] == (characterl.st + characterl.magst)
+          || (tt == 0 && characterl.st + characterl.magst < 3)
+          || (tt == 18 && characterl.st + characterl.magst > 30) ) {
+          for (t = 0; t < 14; t++)
+            if (caste.specialability[0][t])
+              characterl.spec[t] += stmodif[t][tt];
+        }
+      }
+
+      for (tt = 0; tt < 19; tt++)
+        if (range1[tt] == characterl.de || tt == 0 && characterl.de < 3 || tt == 18 && characterl.de > 30) {
+          for (t = 0; t < 14; t++)
+            if (caste.specialability[0][t])
+              characterl.spec[t] += demodif[t][tt];
+        }
+
+      break;
+    /* end changes */
 
     default:
 

--- a/src/realmz_orig/wear.c
+++ b/src/realmz_orig/wear.c
@@ -166,7 +166,22 @@ short wear(short character, short itemnum, short play) {
       warn(7);
     }
     characterr = c[character];
-    c[character].magst += item.st;
+
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(orthotope): recalculate stats based on strength
+     */
+    if (item.st) {
+      strength(c[character].st + c[character].magst);
+      c[character].damage -= damage;
+      c[character].tohit -= temp;
+      updatespec(2);
+      c[character].magst += item.st;
+      strength(c[character].st + c[character].magst);
+      c[character].damage += damage;
+      c[character].tohit += temp;
+      updatespec(3);
+    }
+    /* end changes */
 
     if (c[character].ac + item.ac < 0)
       c[character].ac = 0;


### PR DESCRIPTION
During character creation, high knowledge/judgment/vitality will grant the same resistance bonuses you would get by increasing those stats to the same level later.

Modifying stats, whether by spell effect/potion or by aging, will now update derived stats (to-hit, damage, armor rating, missile dodge chance, strength- and dex-based special abilities, magic resistance, DR Vs) accordingly.

Magic strength from equipped items is included in determining the above derived stats.