### PR TITLE
Fix on-portrait anims (spells, pots, selection) by adding missing leftshifts

### DIFF
--- a/src/realmz_orig/buttonchoice.c
+++ b/src/realmz_orig/buttonchoice.c
@@ -501,7 +501,10 @@ moveon:
     charselectnew = point.v / 50;
     itemRect.top = charselectnew * 50;
     itemRect.bottom = itemRect.top + 50;
-    itemRect.left = 330;
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(chromancer): Added missing leftshifts where noted inline.
+     * These caused portrait feedback anims to be drawn too far left. */
+    itemRect.left = 330 + leftshift; // Missing leftshift.
     itemRect.right = itemRect.left + 50;
     ploticon3(129, itemRect);
     sound(141);
@@ -518,7 +521,7 @@ moveon:
       charselectnew = point.v / 50;
       itemRect.top = charselectnew * 50;
       itemRect.bottom = itemRect.top + 50;
-      itemRect.left = 330;
+      itemRect.left = 330 + leftshift; // Missing leftshift, as above.
       itemRect.right = itemRect.left + 50;
       ploticon3(130, itemRect);
     }

--- a/src/realmz_orig/combatinfo-combatchoice.c
+++ b/src/realmz_orig/combatinfo-combatchoice.c
@@ -889,7 +889,10 @@ void combatchoice(void) {
 
                 itemRect.top = temptemp * 50;
                 itemRect.bottom = itemRect.top + 50;
-                itemRect.left = 330;
+                /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+                 * NOTE(chromancer): Added missing leftshift here.
+                 * Another portrait press animation was off target. */
+                itemRect.left = 330 + leftshift;
                 itemRect.right = itemRect.left + 50;
 
                 ploticon3(129, itemRect);

--- a/src/realmz_orig/spelleffect.c
+++ b/src/realmz_orig/spelleffect.c
@@ -19,7 +19,9 @@ void spelleffect(short t, short mode) /*** mode 0 = normal, 1 = quickshow ****/
   if (!incombat) {
     bodyrect.top = 50 * t + 9;
     bodyrect.bottom = bodyrect.top + 32;
-    bodyrect.left = 339;
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(chromancer): Added missing leftshift here. This one caused anims to play left of the portrait. */
+    bodyrect.left = 339 + leftshift;
     bodyrect.right = bodyrect.left + 32;
     if ((itemused) && (initems))
       SetPort(GetWindowPort(itemswindow));


### PR DESCRIPTION
issue: portrait frame feedback and spell/potion flash animations draw visibly left of the their intended locations.

cause: When realmz was changed from a hand-tailored 640x480 layout to 800x600, various UI elements were shifted in location from their hardcoded locations by (among other ways) applying `leftshift` to move elements exactly 160px over.

I suspect the source we inherited was never really finished or they just got lazy because several draws are missing the necessary leftshifts. This is the result:

<img width="1620" height="1275" alt="Screenshot 2026-07-12 at 2 25 40 AM" src="https://github.com/user-attachments/assets/11ef681b-98a8-4d42-8067-02cc7427ed80" />

Note the red ball in the item rect which is a draw artifact of an animation which should play over a portrait which exists in a window that is z-under the short sheet to the right (i.e., it should not be seen)

fix:
* add + leftshift at four sites (buttonchoice.c x2, combatchoice, spelleffect)
* that's it

effects:
* pressing a portrait flashes the pressed portrait instead of drawing the frame to its left
* spell/potion anims don't cause artifacts

notes: testing and verification will show mostly nothing, just the absence of incorrect draws in some situations. our current render arch is (I think) not capable of capturing the selection frame anims whether they exist or not. I have a marvelous proof of this which this margin is too small to contain.