### PR TITLE
Fix spell info lights

### DIFF
--- a/src/realmz_orig/castspell.c
+++ b/src/realmz_orig/castspell.c
@@ -475,7 +475,11 @@ back:
 
         updateinfo:
 
-          type = abs(spellinfo.damagetype - 1);
+          /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+           * NOTE(chromancer): Original spellinfo panel had wrong order of ops.
+           * Corrected to use proper index for charm and mental types.
+           */
+          type = abs(spellinfo.damagetype) - 1;
           DrawPicture(non, &typerect);
 
           if ((type > -1) && (type < 6)) {


### PR DESCRIPTION
issue: Closes #296. The cold light is on for charm `damagetype` and the mental light doesn't come on when it should because realmz needs to take the absolute value before the index offset.

fix:
* move parenthesis

effects: lights are now visibly correct.

testing: Built on Mac and verified with Soul Bind (mental light now on) and Charm Foe (cold light stays off)