### PR TITLE
Fix EDIT_TEXT caret rendering

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -324,6 +324,10 @@ public:
   EventRecord get_next_event(uint32_t wait_ms) {
     this->enqueue_pending_events(wait_ms);
     if (this->event_queue.empty()) {
+      auto window = WindowManager::instance().front_window();
+      if (window) {
+        window->idle_text_caret();
+      }
       return this->make_null_event();
     } else {
       EventRecord ev = this->event_queue.front();

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -40,6 +40,7 @@ using ResourceDASM::ResourceFile;
 // Enable these to save an image named debug*.bmp every time the main window or dialog items are recomposited
 static constexpr bool ENABLE_RECOMPOSITE_DEBUG = false;
 static constexpr bool ENABLE_DIALOG_RECOMPOSITE_DEBUG = false;
+static constexpr uint64_t TEXT_CARET_BLINK_INTERVAL_MS = 500;
 bool enable_translucent_window_debug = false;
 static size_t debug_number = 1;
 
@@ -474,10 +475,10 @@ public:
 
         // Draw caret if this item is focused
         auto window = this->owner_window.lock();
-        if (window && window->get_focused_item().get() == this) {
+        if (window && window->is_text_caret_visible() && window->get_focused_item().get() == this) {
           int16_t caret_x = this->rect.left + port.measure_text(text) + 1;
           Point caret_top = {.h = caret_x, .v = this->rect.top};
-          Point caret_bottom = {.h = caret_x, .v = this->rect.bottom};
+          Point caret_bottom = {.h = caret_x, .v = static_cast<int16_t>(this->rect.bottom - 1)};
           port.draw_line(caret_top, caret_bottom);
         }
         break;
@@ -982,17 +983,50 @@ std::shared_ptr<DialogItem> Window::get_focused_item() {
   return focused_item;
 }
 
+bool Window::is_text_caret_visible() const {
+  return text_caret_visible;
+}
+
 CCGrafPort& Window::get_port() {
   return this->port;
 }
 
 void Window::set_focused_item(std::shared_ptr<DialogItem> item) {
+  if (focused_item && (focused_item != item)) {
+    text_caret_visible = false;
+    focused_item->render_in_port(this->port, true);
+  }
   focused_item = item;
+  reset_text_caret();
+  item->render_in_port(this->port, true);
+  WindowManager::instance().recomposite_from_window(this->port);
+}
+
+void Window::reset_text_caret() {
+  text_caret_visible = true;
+  text_caret_next_toggle = SDL_GetTicks() + TEXT_CARET_BLINK_INTERVAL_MS;
+}
+
+void Window::idle_text_caret() {
+  if (!focused_item) {
+    return;
+  }
+
+  uint64_t now = SDL_GetTicks();
+  if (text_caret_next_toggle && (now < text_caret_next_toggle)) {
+    return;
+  }
+
+  text_caret_visible = text_caret_next_toggle ? !text_caret_visible : true;
+  text_caret_next_toggle = now + TEXT_CARET_BLINK_INTERVAL_MS;
+  focused_item->render_in_port(this->port, true);
+  WindowManager::instance().recomposite_from_window(this->port);
 }
 
 void Window::handle_text_input(const std::string& text, std::shared_ptr<DialogItem> item) {
   this->log.debug_f("Window::handle_text_input(\"{}\", {})", text, item->str());
   item->append_text(text);
+  reset_text_caret();
   item->render_in_port(this->port, true);
   WindowManager::instance().recomposite_from_window(this->port);
 }
@@ -1000,6 +1034,7 @@ void Window::handle_text_input(const std::string& text, std::shared_ptr<DialogIt
 void Window::delete_char(std::shared_ptr<DialogItem> item) {
   this->log.debug_f("Window::delete_char({})", item->str());
   item->delete_char();
+  reset_text_caret();
   item->render_in_port(this->port, true);
   WindowManager::instance().recomposite_from_window(this->port);
 }
@@ -1912,8 +1947,8 @@ Boolean DialogSelect(const EventRecord* ev, DialogPtr* dialog, short* item_hit) 
   // return false, which takes care of (3). We may have to implement (4) to
   // activate SDL edit controls when the user clicks them (TODO). We may also
   // have to implement (5) later on. (6) is implemented; Realmz uses it for a
-  // lot of interactions. (7) and (8) don't do anything, so they're technically
-  // implemented as well.
+  // lot of interactions. (7) requires no action, and (8) is handled when the
+  // event queue is idle.
 
   auto window = WindowManager::instance().window_for_port(CCGrafPort::as_port(ev->window_port));
 

--- a/src/WindowManager.hpp
+++ b/src/WindowManager.hpp
@@ -28,8 +28,12 @@ private:
   std::vector<std::shared_ptr<DialogItem>> control_items;
   std::vector<std::shared_ptr<DialogItem>> text_items;
   std::shared_ptr<DialogItem> focused_item;
+  bool text_caret_visible = false;
+  uint64_t text_caret_next_toggle = 0;
   std::shared_ptr<Window> window_below;
   std::shared_ptr<Window> window_above;
+
+  void reset_text_caret();
 
   Window(
       const std::string& title,
@@ -71,7 +75,9 @@ public:
   void add_dialog_item(std::shared_ptr<DialogItem> item);
   CCGrafPort& get_port();
   std::shared_ptr<DialogItem> get_focused_item();
+  bool is_text_caret_visible() const;
   void set_focused_item(std::shared_ptr<DialogItem> item);
+  void idle_text_caret();
   void handle_text_input(const std::string& text, std::shared_ptr<DialogItem> item);
   void delete_char(std::shared_ptr<DialogItem> item);
   void erase_and_render();


### PR DESCRIPTION
Fixes #166.

The current `EDIT_TEXT` implementation always draws a solid caret while the field has focus. It also draws the caret one pixel outside the field's erased area, which can leave dots or lines behind as text is entered.

<img width="401" height="216" alt="image" src="https://github.com/user-attachments/assets/4a2e166b-5724-4a42-832d-bfa09f81b1b2" />

Realmz 7.1.2 uses the normal TextEdit idle behavior to blink the caret. This adds the equivalent behavior to the port, keeps the caret visible while typing, and confines it to the editable field so it erases cleanly.

Caret idle updates are handled when the event queue is empty.

Tested with the Add Divinity Scenario text entry dialog and compared with 7.1.2.

<img width="409" height="263" alt="image" src="https://github.com/user-attachments/assets/c396cce8-18e0-4390-b939-c937e0b2839c" />