### PR TITLE
Fix scenario dialog retry

### DIFF
--- a/src/realmz_orig/misc.c
+++ b/src/realmz_orig/misc.c
@@ -1311,7 +1311,12 @@ void adddelscen(short mode) {
         }
       }
 
-      t = DialogSelect(&gTheEvent, &dummy, &itemHit);
+      /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+       * NOTE(iSynic): Ignore dialog events that did not select an item.
+       */
+      if (!DialogSelect(&gTheEvent, &dummy, &itemHit))
+        continue;
+      /* *** END CHANGES *** */
     pushkey:
 
       if (itemHit == 1) {


### PR DESCRIPTION
After an unsuccessful Add Divinity Scenario attempt, reopening the dialog and typing another name would close it again on the first keypress.

The dialog was ignoring the return value from `DialogSelect()`, so text input could leave the previous OK item number in `itemHit` and be treated as another submission.

This only handles `itemHit` when `DialogSelect()` reports that a dialog item was selected. Pressing Return and clicking OK still follow the existing paths.

Tested by entering an invalid scenario name, reopening Add Divinity Scenario, and entering another name without restarting Realmz.