### PR TITLE
Center map content in the enlarged viewport

### DIFF
--- a/src/realmz_orig/mapstuff.c
+++ b/src/realmz_orig/mapstuff.c
@@ -63,7 +63,7 @@ void showmap(short mapnumber) {
   PicHandle picture = NIL;
   Rect temprect, margin;
   Rect maprect;
-  Boolean centeredgeneratedmap = FALSE;
+  Boolean centeredmapcontent = FALSE;
   /* *** END CHANGES *** */
   short oldview, t, tt, temp, tempisdung;
 
@@ -83,31 +83,34 @@ void showmap(short mapnumber) {
 
   viewtype = -1;
 
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(iSynic): Center Classic 320x320 map content in the enlarged viewport.
+   */
+  SetRect(&maprect, 0, 0, 320, 320);
+  OffsetRect(&maprect, lookrect.left + ((lookrect.right - lookrect.left) - 320) / 2,
+      lookrect.top + ((lookrect.bottom - lookrect.top) - 320) / 2);
+  /* *** END CHANGES *** */
+
   if (themap.show < 0) {
     movie(themap.show, 129, 0);
     goto out;
   } else if (themap.pictid) {
     /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-     * NOTE(iSynic): Center picture-backed maps at native size unless the map defines a draw rect.
+     * NOTE(iSynic): Draw default picture-backed maps into the centered Classic map rect.
      */
     SetPort(GetWindowPort(look));
     picture = GetPicture(themap.pictid);
     if (picture) {
-      itemRect = (**picture).picFrame;
-      OffsetRect(&itemRect, -itemRect.left, -itemRect.top);
+      itemRect = maprect;
 
       ForeColor(blackColor);
       PaintRect(&lookrect);
 
       if ((themap.rect[2]) || (themap.rect[3])) {
-        itemRect.top = themap.rect[0];
-        itemRect.left = themap.rect[1];
-        itemRect.bottom = themap.rect[2];
-        itemRect.right = themap.rect[3];
-      } else {
-        OffsetRect(&itemRect, lookrect.left + ((lookrect.right - lookrect.left) - itemRect.right) / 2,
-            lookrect.top + ((lookrect.bottom - lookrect.top) - itemRect.bottom) / 2);
+        SetRect(&itemRect, themap.rect[1], themap.rect[0], themap.rect[3], themap.rect[2]);
+        OffsetRect(&itemRect, maprect.left, maprect.top);
       }
+      centeredmapcontent = TRUE;
 
       DrawPicture(picture, &itemRect);
     }
@@ -118,10 +121,7 @@ void showmap(short mapnumber) {
     /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
      * NOTE(iSynic): Center generated land maps at their Classic 320x320 size.
      */
-    SetRect(&maprect, 0, 0, 320, 320);
-    OffsetRect(&maprect, lookrect.left + ((lookrect.right - lookrect.left) - 320) / 2,
-        lookrect.top + ((lookrect.bottom - lookrect.top) - 320) / 2);
-    centeredgeneratedmap = !themap.isdungeon;
+    centeredmapcontent = !themap.isdungeon;
     /* *** END CHANGES *** */
 
     temp = 320 / themap.iconsize;
@@ -204,9 +204,9 @@ void showmap(short mapnumber) {
         }
 
         /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-         * NOTE(iSynic): Keep authored overlay icons aligned with the centered land map.
+         * NOTE(iSynic): Keep authored overlay icons aligned with centered map content.
          */
-        if (centeredgeneratedmap)
+        if (centeredmapcontent)
           OffsetRect(&temprect, maprect.left, maprect.top);
         /* *** END CHANGES *** */
 
@@ -238,9 +238,9 @@ void showmap(short mapnumber) {
         icon.bottom = icon.top + 64;
 
         /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-         * NOTE(iSynic): Keep the party marker aligned with the centered land map.
+         * NOTE(iSynic): Keep the party marker aligned with centered map content.
          */
-        if (centeredgeneratedmap)
+        if (centeredmapcontent)
           OffsetRect(&icon, maprect.left, maprect.top);
         /* *** END CHANGES *** */
 
@@ -250,9 +250,9 @@ void showmap(short mapnumber) {
   }
 
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-   * NOTE(iSynic): Crop generated land maps to their centered 320x320 presentation.
+   * NOTE(iSynic): Crop centered map content to its Classic 320x320 presentation.
    */
-  if (centeredgeneratedmap) {
+  if (centeredmapcontent) {
     ForeColor(blackColor);
 
     margin = lookrect;

--- a/src/realmz_orig/mapstuff.c
+++ b/src/realmz_orig/mapstuff.c
@@ -58,8 +58,9 @@ void showmap(short mapnumber) {
   DialogRef show;
   Boolean tag = FALSE;
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
-   * NOTE(iSynic): Track the centered generated land-map presentation.
+   * NOTE(iSynic): Track the centered native-size map presentation.
    */
+  PicHandle picture = NIL;
   Rect temprect, margin;
   Rect maprect;
   Boolean centeredgeneratedmap = FALSE;
@@ -86,15 +87,31 @@ void showmap(short mapnumber) {
     movie(themap.show, 129, 0);
     goto out;
   } else if (themap.pictid) {
-    itemRect = lookrect;
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(iSynic): Center picture-backed maps at native size unless the map defines a draw rect.
+     */
     SetPort(GetWindowPort(look));
-    if ((themap.rect[2]) || (themap.rect[3])) {
-      itemRect.top = themap.rect[0];
-      itemRect.left = themap.rect[1];
-      itemRect.bottom = themap.rect[2];
-      itemRect.right = themap.rect[3];
+    picture = GetPicture(themap.pictid);
+    if (picture) {
+      itemRect = (**picture).picFrame;
+      OffsetRect(&itemRect, -itemRect.left, -itemRect.top);
+
+      ForeColor(blackColor);
+      PaintRect(&lookrect);
+
+      if ((themap.rect[2]) || (themap.rect[3])) {
+        itemRect.top = themap.rect[0];
+        itemRect.left = themap.rect[1];
+        itemRect.bottom = themap.rect[2];
+        itemRect.right = themap.rect[3];
+      } else {
+        OffsetRect(&itemRect, lookrect.left + ((lookrect.right - lookrect.left) - itemRect.right) / 2,
+            lookrect.top + ((lookrect.bottom - lookrect.top) - itemRect.bottom) / 2);
+      }
+
+      DrawPicture(picture, &itemRect);
     }
-    pict(themap.pictid, itemRect);
+    /* *** END CHANGES *** */
   } else {
     int enable_recomposite = WindowManager_SetEnableRecomposite(0);
 

--- a/src/realmz_orig/mapstuff.c
+++ b/src/realmz_orig/mapstuff.c
@@ -57,7 +57,13 @@ void showmap(short mapnumber) {
   FILE* fp = NULL;
   DialogRef show;
   Boolean tag = FALSE;
-  Rect temprect;
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(iSynic): Track the centered generated land-map presentation.
+   */
+  Rect temprect, margin;
+  Rect maprect;
+  Boolean centeredgeneratedmap = FALSE;
+  /* *** END CHANGES *** */
   short oldview, t, tt, temp, tempisdung;
 
   tempisdung = indung;
@@ -92,6 +98,15 @@ void showmap(short mapnumber) {
   } else {
     int enable_recomposite = WindowManager_SetEnableRecomposite(0);
 
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(iSynic): Center generated land maps at their Classic 320x320 size.
+     */
+    SetRect(&maprect, 0, 0, 320, 320);
+    OffsetRect(&maprect, lookrect.left + ((lookrect.right - lookrect.left) - 320) / 2,
+        lookrect.top + ((lookrect.bottom - lookrect.top) - 320) / 2);
+    centeredgeneratedmap = !themap.isdungeon;
+    /* *** END CHANGES *** */
+
     temp = 320 / themap.iconsize;
     if (temp * themap.iconsize < 320)
       temp++;
@@ -115,7 +130,12 @@ void showmap(short mapnumber) {
     temprect.top = temprect.left = 0;
     temprect.right = temprect.bottom = themap.iconsize;
 
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(iSynic): Place generated land-map tiles within the centered map rect.
+     */
     if (!indung) {
+      PaintRect(&lookrect);
+      OffsetRect(&temprect, maprect.left, maprect.top);
       for (t = themap.starty; t < temp + themap.starty; t++) {
         for (tt = themap.startx; tt < themap.startx + temp; tt++) {
           fastplotmap(field[tt][t], temprect);
@@ -123,7 +143,9 @@ void showmap(short mapnumber) {
         }
         OffsetRect(&temprect, -(themap.iconsize * temp), themap.iconsize);
       }
-    } else {
+    }
+    /* *** END CHANGES *** */
+    else {
       SetPort(GetWindowPort(look));
       ForeColor(blackColor);
       BackColor(whiteColor);
@@ -164,6 +186,13 @@ void showmap(short mapnumber) {
           InsetRect(&temprect, -((32 - themap.iconsize) / 2), -((32 - themap.iconsize) / 2));
         }
 
+        /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+         * NOTE(iSynic): Keep authored overlay icons aligned with the centered land map.
+         */
+        if (centeredgeneratedmap)
+          OffsetRect(&temprect, maprect.left, maprect.top);
+        /* *** END CHANGES *** */
+
         if (iconhand) {
           PlotCIcon(&temprect, iconhand);
           DisposeCIcon(iconhand);
@@ -191,10 +220,43 @@ void showmap(short mapnumber) {
         icon.right = icon.left + 64;
         icon.bottom = icon.top + 64;
 
+        /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+         * NOTE(iSynic): Keep the party marker aligned with the centered land map.
+         */
+        if (centeredgeneratedmap)
+          OffsetRect(&icon, maprect.left, maprect.top);
+        /* *** END CHANGES *** */
+
         ploticon3(138, icon);
       }
     }
   }
+
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(iSynic): Crop generated land maps to their centered 320x320 presentation.
+   */
+  if (centeredgeneratedmap) {
+    ForeColor(blackColor);
+
+    margin = lookrect;
+    margin.right = maprect.left;
+    PaintRect(&margin);
+
+    margin = lookrect;
+    margin.left = maprect.right;
+    PaintRect(&margin);
+
+    margin = maprect;
+    margin.top = lookrect.top;
+    margin.bottom = maprect.top;
+    PaintRect(&margin);
+
+    margin = maprect;
+    margin.top = maprect.bottom;
+    margin.bottom = lookrect.bottom;
+    PaintRect(&margin);
+  }
+  /* *** END CHANGES *** */
 
   /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
    * NOTE(iSynic): Use the large-screen map note dialog and match the spell


### PR DESCRIPTION
Addresses part of #259.

The 800x600 conversion left maps authored for a 320x320 display area drawing from the top-left of the enlarged viewport.

This keeps generated land maps at their original 320x320 coverage and centers them in the game viewport. Overlay icons and the party marker remain aligned with the map, and the small amount of tile spill that the original 320x320 port would have clipped is hidden again.

Picture-backed maps remain at their native size. Maps with an authored destination rectangle still use it; maps without one are centered.

This does not change map data, zoom, or the number of tiles displayed.

<img width="802" height="652" alt="image" src="https://github.com/user-attachments/assets/7f3c631f-b317-492a-b20e-d1674c22883a" />

<img width="802" height="652" alt="image" src="https://github.com/user-attachments/assets/e5fd2ca7-33f2-4556-9162-96013916b4fb" />