### PR TITLE
Restore map note presentation

### DIFF
--- a/src/realmz_orig/mapstuff.c
+++ b/src/realmz_orig/mapstuff.c
@@ -222,7 +222,11 @@ void showmap(short mapnumber) {
   else
     loadland(dunglevel, TRUE);
 
-  flashmessage((StringPtr) "Click Mouse", 350, 100, 0, 30005);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(iSynic): Keep the map prompt over the status panel in the enlarged layout.
+   */
+  flashmessage((StringPtr) "Click Mouse", 350 + leftshift, 100, 0, 30005);
+  /* *** END CHANGES *** */
 
   xy(0);
   DisposeDialog(show);

--- a/src/realmz_orig/mapstuff.c
+++ b/src/realmz_orig/mapstuff.c
@@ -196,11 +196,16 @@ void showmap(short mapnumber) {
     }
   }
 
-  show = GetNewDialog(169, 0L, (WindowPtr)-1L);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(iSynic): Use the large-screen map note dialog and match the spell
+   * description panel placement.
+   */
+  show = GetNewDialog(169 + (1000 * screensize), 0L, (WindowPtr)-1L);
   SetPortDialogPort(show);
   BackPixPat(base);
   TextFont(defaultfont);
-  MoveWindow(GetDialogWindow(show), GlobalLeft - 1 + (leftshift / 2), GlobalTop + 321 + (downshift / 2), FALSE);
+  MoveWindow(GetDialogWindow(show), GlobalLeft - 1, GlobalTop + 321 + downshift, FALSE);
+  /* *** END CHANGES *** */
   ForeColor(yellowColor);
   gCurrent = show;
   ShowWindow(GetDialogWindow(show));


### PR DESCRIPTION
Addresses part of #259.

The enlarged layout was still using the original map-note dialog and positioning both it and the `Click Mouse` prompt with the old screen coordinates.

This uses the existing large-screen dialog, places it over the lower-left message panel, and restores the yellow outline around the note text. The `Click Mouse` prompt is moved over the right-side status panel so it no longer obscures the map.

<img width="802" height="652" alt="image" src="https://github.com/user-attachments/assets/f9cc851f-513c-4637-9041-d41a8d5a45f3" />
