### PR TITLE
Restore 3D dungeon view presentation

### DIFF
--- a/src/QuickDraw.cpp
+++ b/src/QuickDraw.cpp
@@ -49,6 +49,8 @@ static std::unordered_map<int16_t, ResourceDASM::BitmapFontRenderer> bm_renderer
 
 std::unordered_set<const CCGrafPort*> CCGrafPort::all_ports;
 
+static phosg::ImageRGB888 reference_image_for_ppat(PixPatHandle ppat);
+
 CCGrafPort* CCGrafPort::as_port(void* ptr) {
   auto* port_ptr = reinterpret_cast<CCGrafPort*>(ptr);
   return all_ports.count(port_ptr) ? port_ptr : nullptr;
@@ -114,6 +116,24 @@ void CCGrafPort::erase_rect(const Rect& r) {
 }
 
 void CCGrafPort::fill_rect(const Rect& r) {
+  if (this->pnMode == 0x08) { // patCopy
+    if (!this->pnPixPat) {
+      throw std::logic_error("Cannot draw with patCopy mode unless PenPixPat was previously set");
+    }
+    const auto pattern = reference_image_for_ppat(this->pnPixPat);
+    ssize_t x = r.left;
+    ssize_t y = r.top;
+    ssize_t w = r.right - r.left;
+    ssize_t h = r.bottom - r.top;
+    this->data.clamp_rect(x, y, w, h);
+    for (ssize_t py = y; py < y + h; py++) {
+      for (ssize_t px = x; px < x + w; px++) {
+        this->data.write(px, py, pattern.read(px % pattern.get_width(), py % pattern.get_height()));
+      }
+    }
+    return;
+  }
+
   uint32_t color = rgba8888_for_rgb_color(this->rgbFgColor);
   this->data.write_rect(r.left, r.top, r.right - r.left, r.bottom - r.top, color);
 }

--- a/src/realmz_orig/MacrocosmMain.c
+++ b/src/realmz_orig/MacrocosmMain.c
@@ -6,8 +6,12 @@ void updatecompass(void) {
   Rect testRect;
   short temphead;
 
-  testRect.top = 251 + downshift / 2;
-  testRect.bottom = testRect.top + 69;
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(iSynic): Keep the dungeon compass docked above the lower interface panel.
+   */
+  testRect.bottom = lookrect.bottom;
+  testRect.top = testRect.bottom - 69;
+  /* *** END CHANGES *** */
   testRect.left = 93 + leftshift / 2;
   testRect.right = testRect.left + 133;
 


### PR DESCRIPTION
Addresses part of #259.

The enlarged layout left two presentation differences in the 3D dungeon view.

The SDL QuickDraw implementation rendered `FillRect()` as a solid color even when Realmz selected `patCopy` with `PenPixPat()`. This caused the original blue patterned background to be replaced by a solid fill.

The 800x600 layout also offset the compass by half of the added viewport height, leaving it floating above the lower interface instead of sitting directly above it.

This adds patterned `FillRect()` support using the existing PixPat decoder and anchors the bottom of the compass to the bottom of the gameplay viewport. Other fill modes, the compass size, and the centered 3D view are unchanged.

I submitted the two changes as separate commits in the hope they'd be easier to review.

<img width="802" height="652" alt="image" src="https://github.com/user-attachments/assets/f77a5f6a-c1c5-4b61-8472-349ee07ca86b" />