### PR TITLE
Stop dropping treasure screen clicks made during the item animation

### DIFF
--- a/src/realmz_orig/textbox-time.c
+++ b/src/realmz_orig/textbox-time.c
@@ -123,7 +123,15 @@ void textbox(short class, short index, short click, short different, Rect newrec
   }
 out:
 
-  FlushEvents(everyEvent, 0);
+  /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+   * NOTE(afkelsall): This flush ran unconditionally, so the passive path
+   * (click FALSE, used for messages drawn without waiting for a dismissal)
+   * also discarded input that had arrived while the game was busy drawing.
+   * Only the click path needs the flush, to drop the remnants of the
+   * dismissing click. */
+  if (click)
+    FlushEvents(everyEvent, 0);
+  /* *** END CHANGES *** */
   different = 0;
   TextFace(bold);
   TextFont(font);


### PR DESCRIPTION
Clicking items in quick succession on the post-fight treasure screen silently loses some of them: the click registers, nothing happens, and the item has to be clicked again.

Why:
- `textbox` ends with an unconditional `FlushEvents(everyEvent, 0)`, which discards everything queued at that moment.
- Only the `click` path needs it, to drop the remnants of the click that dismissed the message. The passive path (`click` FALSE) draws a message and returns, so the flush there just destroys unrelated input.
- The treasure screen item hover preview goes through that passive path (`quickinfo` -> `textbox`). Redrawing the preview for a cell therefore flushes the queue.
- A click made while the previous item's keep animation is running is queued, then destroyed by the next hover redraw before the event loop can dequeue it, so that item is never taken. The animation blocks for roughly 100 to 250 ms, which is the window where this happens.
- Original game logic (`src/realmz_orig/`), not the SDL shim, and the same defect on macOS and Windows.

How:
- Guard the trailing flush with `if (click)`, so only the modal dismissal path clears the queue.
- Verified with event logging: before the change, queued `mouseDown` events on the treasure screen were cleared without ever being dequeued; after it, clicks made during the animation survive and are processed.
- Touches only shared game code, so it behaves the same on macOS and Windows.