### PR TITLE
add marks to Mac popups

### DIFF
--- a/src/macos/MenuController.mm
+++ b/src/macos/MenuController.mm
@@ -13,6 +13,8 @@ NSMenu* MCCreateSubMenu(NSString* title, const Menu& menuRes, const std::list<st
 // We have to forward declare because of PixMap collision w/QuickDraw
 phosg::ImageRGBA8888N DecodeCIconImage(int16_t iconID);
 
+static constexpr char kDiamondMark = 19;
+
 // Wraps a decoded cicn as an NSImage, NN scale 2x, byteswap BGRA->RGBA.
 static constexpr NSInteger kMenuIconUpscale = 2;
 
@@ -224,7 +226,7 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
         subMenuItem.enabled = subMenuItemRes.enabled;
         bool mark_is_submenu_link = (subMenuItemRes.key_equivalent == 0x1B);
         char mark = mark_is_submenu_link ? 0 : subMenuItemRes.mark_character;
-        if (subMenuItemRes.checked || mark == 19) {
+        if (subMenuItemRes.checked || mark == kDiamondMark) {
           subMenuItem.state = NSControlStateValueOn;
         } else if (mark != 0) {
           subMenuItem.state = NSControlStateValueMixed;
@@ -300,6 +302,11 @@ static NSImage* MCImageForCicn(int16_t cicnID) {
     id menuIdentifier = [[MCMenuItemIdentifier alloc] initWithRawIds:menu->menu_id itemId:itemId];
     [menuItem setRepresentedObject:menuIdentifier];
     menuItem.enabled = item.enabled;
+    if (item.checked || item.mark_character == kDiamondMark) {
+      menuItem.state = NSControlStateValueOn;
+    } else if (item.mark_character != 0) {
+      menuItem.state = NSControlStateValueMixed;
+    }
     NSImage* icon = MCImageForCicn(item.icon_id);
     if (icon != nil) {
       [menuItem setImage:icon];


### PR DESCRIPTION
issue: Current Native mac popup menus don't have marks, just icons. #235 added marks *only* in menu bar for Mac and #230 added icons for menus and popups. I meant to come back for popups but never did. Last nail and closes #202.

Mac only as Windows has handled this separately in #264.

fix:

- apply menu bar mapping to popup rows: checked flag or diamond mark (19) → NSControlStateValueOn (check), any other mark → NSControlStateValueMixed (dash)
- add constant kDiamondMark

effects:

- equipped items, the source character, and permanent conditions show check.
- temporary conditions show dash.
- monster items revealed by Detect Magic show check.
- rows with portraits show mark and icon together.

notes: I wonder about using diamonds from SF Symbols later. I'll test how it looks.

testing: built on Mac 26.5.2. Verified visually.