### PR TITLE
Guard against empty pref file decoding

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -400,12 +400,18 @@ int16_t FSpOpenResFile(const FSSpec* spec, SInt8 permission) {
     }
 
     std::string data = phosg::load_file(host_filename);
-    std::shared_ptr<ResourceDASM::ResourceFile> rf;
-    try {
-      rf = std::make_shared<ResourceDASM::ResourceFile>(
-          ResourceDASM::parse_applesingle_appledouble_resource_fork(data));
-      rm_log.info_f("Loaded AppleSingle/AppleDouble resource fork from {}", host_filename.c_str());
-    } catch (const std::runtime_error&) {
+    std::shared_ptr<ResourceDASM::ResourceFile> rf = nullptr;
+    if (data.length() > 0) {
+      try {
+        rf = std::make_shared<ResourceDASM::ResourceFile>(
+            ResourceDASM::parse_applesingle_appledouble_resource_fork(data));
+        rm_log.info_f("Loaded AppleSingle/AppleDouble resource fork from {}", host_filename.c_str());
+      } catch (const std::runtime_error&) {
+        rf = nullptr;
+      }
+    }
+
+    if (!rf) {
       rf = std::make_shared<ResourceDASM::ResourceFile>(ResourceDASM::parse_resource_fork(data));
     }
     bool writable = (permission == fsCurPerm) || (permission > fsRdPerm);


### PR DESCRIPTION
#281 changed the implementation of `FSpOpenResFile` to account for some legacy scenarios which use a different resource file format. This change checks for these legacy formats by first attempting to decode the file as those formats, catching any `runtime_error` that results, and falling back to the previous behavior of just calling `ResourceDASM::parse_resource_fork`.

However, while `parse_resource_fork` correctly handled the case where empty data is passed (by returning an empty resource file), the new `parse_applesingle_appledouble_resource_fork` does not, throwing a `out_of_bounds` error because it assumes there is enough data to attempt to parse a Header-sized chunk. This caused a breakage in Realmz startup logic, where a new, empty preferences resource file is created, then immediately passed to `FSpOpenResFile` for populating.

This PR only attempts the new decode path if there is file data, and reverts to the old logic if the data is empty or parsing via `parse_applesingle_appledouble_resource_fork` fails.