### PR TITLE
Hotfix third-party scenario startup crash

### DIFF
--- a/src/realmz_orig/pref.c
+++ b/src/realmz_orig/pref.c
@@ -404,16 +404,23 @@ void getpref(void) {
     serial += Rand(32000);
     MyrBitSetLong(&serial, 8);
     MyrBitSetLong(&serial, 6 + divine);
-    appnum = serial;
-
-    PtoCstr((StringPtr)myString);
-
-    if ((fp = MyrFopen((Ptr)myString, "r+b")) != NIL) {
-      CvtLongToPc(&appnum);
-      fwrite(&appnum, sizeof appnum, 1, fp);
-      CvtLongToPc(&appnum);
-      fclose(fp);
-    }
+    /* *** CHANGED FROM ORIGINAL IMPLEMENTATION ***
+     * NOTE(iSynic): Disabled the application-file serial writeback. This port
+     * persists mutable preference data through the user preference resource
+     * file, and myString may contain the current scenario name while selecting
+     * third-party scenarios.
+     */
+    // appnum = serial;
+    //
+    // PtoCstr((StringPtr)myString);
+    //
+    // if ((fp = MyrFopen((Ptr)myString, "r+b")) != NIL) {
+    //   CvtLongToPc(&appnum);
+    //   fwrite(&appnum, sizeof appnum, 1, fp);
+    //   CvtLongToPc(&appnum);
+    //   fclose(fp);
+    // }
+    /* *** END CHANGES *** */
   }
 #endif
 


### PR DESCRIPTION
## Summary

This removes an old serial writeback path from preference loading.

The old code repairs an invalid/missing serial, then tries to write that serial back into the app file using `myString` as the filename. In the modern build, prefs live in the user prefs resource file, and `myString` is shared scratch state.

## What was happening

When starting Trial By Fire, `myString` could contain the scenario name. The old code then called `PtoCstr(myString)`, which treated `Trial By Fire` like a Pascal string and mangled it into something like `rial By Fire`.

That bad path then got passed into `MyrFopen(..., "r+b")`, and the modern file manager rejected it as an unsupported absolute/bare path, causing the crash.

I don't think this was introduced by the AppleDouble work directly. The AppleDouble/resource-sidecar fixes just made more third-party scenarios load far enough to hit it.

## Fix

Keep the serial repair, but remove the obsolete app-file writeback. The modern build already stores mutable prefs in the user preference resource file, and the registration bypass below this block still handles the current behavior.

## Testing

Built a Release build and verified Trial By Fire starts without the crash.