### PR TITLE
Enable high pixel density rendering

### DIFF
--- a/bundle/Info.plist.in
+++ b/bundle/Info.plist.in
@@ -28,5 +28,7 @@
     <string>@PROJECT_COPYRIGHT@</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.3</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
 </dict>
 </plist>

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1260,7 +1260,9 @@ void WindowManager::create_sdl_window() {
   this->windowed_x = prefs.window_x;
   this->windowed_y = prefs.window_y;
 
-  this->sdl_window = sdl_make_shared(SDL_CreateWindow("Realmz", prefs.window_w, prefs.window_h, SDL_WINDOW_RESIZABLE));
+  this->sdl_window = sdl_make_shared(SDL_CreateWindow(
+      "Realmz", prefs.window_w, prefs.window_h,
+      SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY));
   if (!this->sdl_window) {
     throw std::runtime_error(std::format("Could not create SDL window: {}", SDL_GetError()));
   }


### PR DESCRIPTION
Addresses #113.

## What changed

- Request a high-pixel-density drawable when creating the SDL window.
- Mark the macOS application bundle as high-resolution capable.

## Why

Realmz currently creates a normal-density window even on Retina displays, leaving macOS to scale the rendered output to the display's backing resolution. This appears to be why the image becomes softer or thicker after sitting idle on affected Retina displays, while continuous animation keeps it crisp.

This keeps Realmz's existing 800x600 logical presentation and apparent window size. It only allows SDL to provide a higher-resolution drawable on displays that support it; normal-density displays should continue using a 1x drawable.

## Verification

- Windows build passes.
- Built and validated a universal macOS Release test DMG containing this change.
- Tested by Discord user `mrproud`, who reports that this solution works.