### PR TITLE
use left and right mod keys

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -456,11 +456,11 @@ protected:
         // control-character KCHR table and break Command-key shortcuts and typed characters.
         this->set_modifier_value(EVMOD_CONTROL_KEY_DOWN, false);
 #else
-        this->set_modifier_value(EVMOD_CONTROL_KEY_DOWN, e.key.mod & SDL_KMOD_LCTRL);
+        this->set_modifier_value(EVMOD_CONTROL_KEY_DOWN, e.key.mod & SDL_KMOD_CTRL);
 #endif
-        this->set_modifier_value(EVMOD_OPTION_KEY_DOWN, e.key.mod & SDL_KMOD_LALT);
+        this->set_modifier_value(EVMOD_OPTION_KEY_DOWN, e.key.mod & SDL_KMOD_ALT);
         this->set_modifier_value(EVMOD_CAPS_LOCK_ENABLED, e.key.mod & SDL_KMOD_CAPS);
-        this->set_modifier_value(EVMOD_SHIFT_KEY_DOWN, e.key.mod & SDL_KMOD_LSHIFT);
+        this->set_modifier_value(EVMOD_SHIFT_KEY_DOWN, e.key.mod & SDL_KMOD_SHIFT);
 #ifdef _WIN32
         // The Windows (Super) key is reserved by the OS for the Start menu and shell shortcuts, so
         // it cannot reliably act as the Mac Command key. Map the Control key to Command instead.

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -464,7 +464,7 @@ protected:
 #ifdef _WIN32
         // The Windows (Super) key is reserved by the OS for the Start menu and shell shortcuts, so
         // it cannot reliably act as the Mac Command key. Map the Control key to Command instead.
-        this->set_modifier_value(EVMOD_COMMAND_KEY_DOWN, e.key.mod & SDL_KMOD_LCTRL);
+        this->set_modifier_value(EVMOD_COMMAND_KEY_DOWN, e.key.mod & SDL_KMOD_CTRL);
 #else
         this->set_modifier_value(EVMOD_COMMAND_KEY_DOWN, e.key.mod & SDL_KMOD_GUI);
 #endif


### PR DESCRIPTION
issue: Closes #132. option, shift, and cmd are using only SDL LALT, LCTRL, LSHIFT, etc.

fix: use SDL's combined masks (SDL_KMOD_ALT/SHIFT/CTRL) for generic

effects: holding left or right mod keys works for all purposes

testing: built on Mac, verified right and left mod keys now work.